### PR TITLE
Add support for mapping reduced bam paths to unreduced paths where required

### DIFF
--- a/scripts/update_workspace_dd.py
+++ b/scripts/update_workspace_dd.py
@@ -19,6 +19,14 @@ FALLBACK_REPLACEMENTS = {
         'replacement': '.bam',
         'notice': 'No reduced bam version migrated, mapped to unreduced instead',
     }
+    '.reduced.bai': {
+        'replacement': '.bai',
+        'notice': 'No reduced bai version migrated, mapped to unreduced instead',
+    }
+    '.reduced.bam.md5': {
+        'replacement': '.bam.md5',
+        'notice': 'No reduced md5 version migrated, mapped to unreduced instead',
+    }
 }
 
 


### PR DESCRIPTION
We've seen cases where users are trying to map paths pointing at the reduced version of a bam which has since been cleaned up. Since we can't build a comprehensive list of all possible bam varieties that might have been in a directory, I instead introduced this system to try mapping other variations of the path if we can't map the path they've given us.