### PR TITLE
[DFE-2781] add + remove terra service banner

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,21 +2,34 @@
 
 ### A.  terra_service_banner.py
 #### Description
-    In the event of a Service Incident related to the Terra UI, SDLC notes that a message must be posted to the platform for users to be made aware of the ongoing issue. The messaging is provided to users of the platform with a modifiable banner.The process of posting the banner has a few steps that are manual but this python script provides a streamlined solution for internal members that are on a suitability roster.
+    In the event of a Service Incident affecting the Terra platform, SDLC states that a message must be posted to the platform for users to be made aware of the ongoing issue. The messaging is provided via the UI with a modifiable banner.The process of posting the banner has a few steps that are manual but this python script provides a streamlined solution for internal members that are on a suitability roster.
 
-    The script can be run to post and delete template banners but is also equipped to handle a custom message via a .json file.
+    The script can be run to post and clear the standard service incident banner but is also equipped to handle a custom message via a .json file.
+
+    The code in this script modifies only a single object, mandatorily named "alerts.json", in a specific bucket. The Terra UI monitors the status of the .json file; if there are contents, a banner is posted, but if the .json is empty, the banner is cleared. 
 
 #### Execution
     1. Authenticate user with the email address that is on the suitability roster:
         `gcloud auth login user@email.com`
     2. Execute script:
-        `python3 terra_service_banner.py --env ["prod" or "dev"] [--delete] [--json path to custom banner .json]`
+        `python3 terra_service_banner.py --env ["prod" or "dev"] [--delete] [--json path to custom_banner.json]`
 
-    Eexample:
+    Example:
     1. To post template banner to the production environment:
-        `python3 modify_dph_headers.py --env prod
-    2. To delete any banner (template or custom) from the production environment:
-        `python3 modify_dph_headers.py --env prod --delete`
+        `python3 terra_service_banner.py --env prod`
+    2. To post custom banner to the production environment:
+        `python3 terra_service_banner.py --env prod --json custom_banner.json`
+    3. To clear the banner (template or custom) from the production environment:
+        `python3 terra_service_banner.py --env prod --delete`
+
+    Example custom_banner.json:
+        ```[
+            {
+                "title":"Example Custom Banner: Service Incident",
+                "message":"We are currently investigating an issue impacting the platform. Information about this incident will be made available here.",
+                "link":"https://support.terra.bio/hc/en-us/sections/360003692231-Service-Notifications"
+            }
+        ]```
 
 #### Output
-    If posting the indicated Terra environment will have either a template or custom banner message and if deleting, any banner that is present will be removed.
+    If posting, the indicated Terra environment will have either a template or custom banner message and if deleting, the banner that is present will be removed.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,22 @@
+## Horsefish Scripts 
+
+### A.  terra_service_banner.py
+#### Description
+    In the event of a Service Incident related to the Terra UI, SDLC notes that a message must be posted to the platform for users to be made aware of the ongoing issue. The messaging is provided to users of the platform with a modifiable banner.The process of posting the banner has a few steps that are manual but this python script provides a streamlined solution for internal members that are on a suitability roster.
+
+    The script can be run to post and delete template banners but is also equipped to handle a custom message via a .json file.
+
+#### Execution
+    1. Authenticate user with the email address that is on the suitability roster:
+        `gcloud auth login user@email.com`
+    2. Execute script:
+        `python3 terra_service_banner.py --env ["prod" or "dev"] [--delete] [--json path to custom banner .json]`
+
+    Eexample:
+    1. To post template banner to the production environment:
+        `python3 modify_dph_headers.py --env prod
+    2. To delete any banner (template or custom) from the production environment:
+        `python3 modify_dph_headers.py --env prod --delete`
+
+#### Output
+    If posting the indicated Terra environment will have either a template or custom banner message and if deleting, any banner that is present will be removed.

--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -2,19 +2,37 @@ import argparse
 from google.cloud import storage as gcs
 
 
-def convert_json_to_string(json, env):
+def convert_json_to_string(env, json):
     """Convert json file to string if supplied with custom banner json file."""
 
     # open json file and read contents to a string
     with open(json, "r") as j:
         custom_banner_string = j.read()
 
-    print(f'Starting custom banner upload to {env} Terra.')
     return(custom_banner_string)
 
 
-def update_service_banner(json, env):
+def update_service_banner(env, json_string=None):
     """Push json to bucket in selected production environment."""
+
+    # if no custom banner json is passed in, post standard banner text/string
+    if not json_string:
+        banner_text = """[
+                        {
+                        "title":"Service Incident",
+                        "message":"We are currently investigating an issue impacting the platform. Information about this incident will be made available here.",
+                        "link":"https://support.terra.bio/hc/en-us/sections/360003692231-Service-Notifications"
+                        }
+                    ]"""
+        print(f'Starting standard banner upload to {env} Terra.')
+    # if json_string is empty, remove banner
+    elif json_string == "[]":
+        banner_text = json_string
+        print(f'Starting banner removal from {env} Terra.')
+    # if custom banner json is passed in, post custom banner text/string
+    else:
+        banner_text = json_string
+        print(f'Starting custom banner upload to {env} Terra.')
 
     # create storage Client and assign destination bucket
     storage_client = gcs.Client()
@@ -29,7 +47,7 @@ def update_service_banner(json, env):
 
     # define required filename (alerts.json) and upload json string to gcs
     blob = bucket.blob("alerts.json")
-    blob.upload_from_string(json)
+    blob.upload_from_string(banner_text)
 
     print(f'Setting permissions and security on banner json object in GCS location.')
     # set metadata on json object (gsutil -m setmeta -r -h "Cache-Control:private, max-age=0, no-cache")
@@ -47,48 +65,30 @@ def update_service_banner(json, env):
     print("Banner action complete.")
 
 
-def post_standard_banner(env):
-    """Create json string for upload to GCS location to post/publish banner."""
-
-    # template json text for banner publication
-    banner_text = """[
-                        {
-                        "title":"Service Incident",
-                        "message":"We are currently investigating an issue impacting the platform. Information about this incident will be made available here.",
-                        "link":"https://support.terra.bio/hc/en-us/sections/360003692231-Service-Notifications"
-                        }
-                    ]"""
-
-    # push json string to bucket - post banner
-    print(f'Starting template banner upload to {env} Terra.')
-    update_service_banner(banner_text, env)
-
-
 def clear_service_banner(env):
     """Create json string for upload to GCS location to clear/remove banner."""
 
     # template json text for banner deletion
-    banner_text = """[]"""
+    clear_banner_text = """[]"""
 
     # push json string to bucket - clear banner
-    print(f'Starting banner removal from {env} Terra.')
-    update_service_banner(banner_text, env)
+    update_service_banner(env, clear_banner_text)
 
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Publish or remove a production incident banner on Terra UI.')
     parser.add_argument('--env', type=str, required=True, help='"prod" or "dev" Terra environment for banner.')
-    parser.add_argument('--json', type=str, help='set to post custom banner (via json file) to Terra UI.')
-    parser.add_argument('--delete', action='store_true', help='set to clear banner from Terra UI.')
+    parser.add_argument('--json', type=str, required=False, help='set to post custom banner (via json file) to Terra UI.')
+    parser.add_argument('--delete', required=False, action='store_true', help='set to clear banner from Terra UI.')
 
     args = parser.parse_args()
 
     # if custom banner
     if args.json:
         # convert json file to string, post banner
-        custom_banner_string = convert_json_to_string(args.json, args.env)
-        update_service_banner(custom_banner_string, args.env)
+        custom_banner_string = convert_json_to_string(args.env, args.json)
+        update_service_banner(args.env, custom_banner_string)
     # if not custom banner
     else:
         # if "--delete" (clear banner)
@@ -96,4 +96,5 @@ if __name__ == '__main__':
             clear_service_banner(args.env)
         # if not "--delete" (post banner)
         else:
-            post_standard_banner(args.env)
+            # post_standard_banner(args.env)
+            update_service_banner(args.env)

--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -1,0 +1,88 @@
+import argparse
+import json
+from google.cloud import storage as gcs
+
+
+def update_service_banner(json, env):
+    """Push json to bucket in selected production environment."""
+    # create storage Client and assign destination bucket
+    storage_client = gcs.Client()
+
+    # set bucket and suitable_group based on env
+    if env == "dev":
+        bucket = storage_client.get_bucket(f"firecloud-alerts-{env}")
+        suitable_group = (f"fc-comms@{env}.test.firecloud.org")
+    else:
+        bucket = storage_client.get_bucket("firecloud-alerts")
+        suitable_group = "fc-comms@firecloud.org"
+
+    # define required filename (alerts.json) and upload json string to gcs
+    blob = bucket.blob("alerts.json")
+    blob.upload_from_string(json)
+
+    print(f'Setting permissions and security on banner json object in GCS location.')
+    # set and save READ access for AllUsers on json object (gsutil ach ch -u AllUsers:R)
+    blob.acl.all().grant_read()
+    blob.acl.save()
+
+    # set and save OWNER access for suitable_group on json object (gsutil ach ch -g suitable_group:O)
+    blob.acl.user(suitable_group).grant_owner()
+    blob.acl.save()
+
+    # set metadata on json object (gsutil -m setmeta -r -h "Cache-Control:private, max-age=0, no-cache")
+    blob.cache_control = "private, max-age=0, no-cache"
+    blob.patch()
+
+    print("Banner action complete.")
+
+
+def post_banner(env):
+    """Create json string for upload to GCS location to post/publish banner."""
+
+    # template json text for banner publication
+    banner_text = """[
+                        {
+                        "title":"Service Incident",
+                        "message":"We are currently investigating an issue impacting the platform. Information about this incident will be made available here.",
+                        "link":"https://support.terra.bio/hc/en-us/sections/360003692231-Service-Notifications"
+                        }
+                    ]"""
+
+    # convert string --> json object --> json formatted string
+    post_json_obj = json.loads(banner_text)
+    post_json = json.dumps(post_json_obj, indent=1)
+
+    # push json string to bucket - post banner
+    print(f'Starting banner upload to {env} Terra.')
+    update_service_banner(post_json, env)
+
+
+def delete_banner(env):
+    """Create json string for upload to GCS location to delete/remove banner."""
+
+    # template json text for banner deletion
+    banner_text = """[]"""
+
+    # convert string --> json object --> json formatted string
+    delete_json_obj = json.loads(banner_text)
+    delete_json = json.dumps(delete_json_obj, indent=1)
+
+    # push json string to bucket - delete banner
+    print(f'Starting banner removal from {env} Terra.')
+    update_service_banner(delete_json, env)
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Publish or remove a production incident banner on Terra UI.')
+    parser.add_argument('--env', required=True, help='"prod" or "dev" environment for banner.')
+    parser.add_argument('--delete', action='store_true', help='set parameter if intention is to remove banner from Terra UI.')
+
+    args = parser.parse_args()
+
+    # if not "--delete", post banner
+    if args.delete:
+        delete_banner(args.env)
+    # if "--delete", remove banner
+    else:
+        post_banner(args.env)

--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -13,7 +13,7 @@ def convert_json_to_string(env, json):
 
 
 def update_service_banner(env, json_string=None):
-    """Push json to bucket in selected production environment."""
+    """Push json to bucket in selected environment."""
 
     # if no custom banner json is passed in, post standard banner text/string
     if not json_string:
@@ -69,7 +69,7 @@ def clear_service_banner(env):
     """Create json string for upload to GCS location to clear/remove banner."""
 
     # template json text for banner deletion
-    clear_banner_text = """[]"""
+    clear_banner_text = "[]"
 
     # push json string to bucket - clear banner
     update_service_banner(env, clear_banner_text)
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Publish or remove a production incident banner on Terra UI.')
     parser.add_argument('--env', type=str, required=True, help='"prod" or "dev" Terra environment for banner.')
-    parser.add_argument('--json', type=str, required=False, help='set to post custom banner (via json file) to Terra UI.')
+    parser.add_argument('--json', type=str, required=False, help='path to json file containing custom banner text.')
     parser.add_argument('--delete', required=False, action='store_true', help='set to clear banner from Terra UI.')
 
     args = parser.parse_args()

--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 from google.cloud import storage as gcs
 
 
@@ -16,6 +15,7 @@ def convert_json_to_string(json, env):
 
 def update_service_banner(json, env):
     """Push json to bucket in selected production environment."""
+
     # create storage Client and assign destination bucket
     storage_client = gcs.Client()
 
@@ -59,13 +59,9 @@ def post_banner(env):
                         }
                     ]"""
 
-    # convert string --> json object --> json formatted string
-    post_json_obj = json.loads(banner_text)
-    post_json = json.dumps(post_json_obj, indent=1)
-
     # push json string to bucket - post banner
     print(f'Starting template banner upload to {env} Terra.')
-    update_service_banner(post_json, env)
+    update_service_banner(banner_text, env)
 
 
 def delete_banner(env):
@@ -74,13 +70,9 @@ def delete_banner(env):
     # template json text for banner deletion
     banner_text = """[]"""
 
-    # convert string --> json object --> json formatted string
-    delete_json_obj = json.loads(banner_text)
-    delete_json = json.dumps(delete_json_obj, indent=1)
-
     # push json string to bucket - delete banner
     print(f'Starting banner removal from {env} Terra.')
-    update_service_banner(delete_json, env)
+    update_service_banner(banner_text, env)
 
 
 if __name__ == '__main__':

--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -9,12 +9,12 @@ def update_service_banner(json, env):
     storage_client = gcs.Client()
 
     # set bucket and suitable_group based on env
-    if env == "dev":
-        bucket = storage_client.get_bucket(f"firecloud-alerts-{env}")
-        suitable_group = (f"fc-comms@{env}.test.firecloud.org")
-    else:
+    if env == "prod":
         bucket = storage_client.get_bucket("firecloud-alerts")
         suitable_group = "fc-comms@firecloud.org"
+    else:
+        bucket = storage_client.get_bucket(f"firecloud-alerts-{env}")
+        suitable_group = (f"fc-comms@{env}.test.firecloud.org")
 
     # define required filename (alerts.json) and upload json string to gcs
     blob = bucket.blob("alerts.json")

--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -10,7 +10,7 @@ def convert_json_to_string(json, env):
         custom_banner_string = j.read()
 
     print(f'Starting custom banner upload to {env} Terra.')
-    update_service_banner(custom_banner_string, env)
+    return(custom_banner_string)
 
 
 def update_service_banner(json, env):
@@ -47,7 +47,7 @@ def update_service_banner(json, env):
     print("Banner action complete.")
 
 
-def post_banner(env):
+def post_standard_banner(env):
     """Create json string for upload to GCS location to post/publish banner."""
 
     # template json text for banner publication
@@ -64,13 +64,13 @@ def post_banner(env):
     update_service_banner(banner_text, env)
 
 
-def delete_banner(env):
-    """Create json string for upload to GCS location to delete/remove banner."""
+def clear_service_banner(env):
+    """Create json string for upload to GCS location to clear/remove banner."""
 
     # template json text for banner deletion
     banner_text = """[]"""
 
-    # push json string to bucket - delete banner
+    # push json string to bucket - clear banner
     print(f'Starting banner removal from {env} Terra.')
     update_service_banner(banner_text, env)
 
@@ -78,21 +78,22 @@ def delete_banner(env):
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Publish or remove a production incident banner on Terra UI.')
-    parser.add_argument('--env', required=True, help='"prod" or "dev" Terra environment for banner.')
-    parser.add_argument('--json', help='set to post custom banner (via json file) to Terra UI.')
-    parser.add_argument('--delete', action='store_true', help='set to delete banner from Terra UI.')
+    parser.add_argument('--env', type=str, required=True, help='"prod" or "dev" Terra environment for banner.')
+    parser.add_argument('--json', type=str, help='set to post custom banner (via json file) to Terra UI.')
+    parser.add_argument('--delete', action='store_true', help='set to clear banner from Terra UI.')
 
     args = parser.parse_args()
 
     # if custom banner
     if args.json:
-        # convert file to string, post banner
-        convert_json_to_string(args.json, args.env)
+        # convert json file to string, post banner
+        custom_banner_string = convert_json_to_string(args.json, args.env)
+        update_service_banner(custom_banner_string, args.env)
     # if not custom banner
     else:
-        # if "--delete" (remove banner)
+        # if "--delete" (clear banner)
         if args.delete:
-            delete_banner(args.env)
+            clear_service_banner(args.env)
         # if not "--delete" (post banner)
         else:
-            post_banner(args.env)
+            post_standard_banner(args.env)

--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -41,7 +41,7 @@ def update_service_banner(json, env):
     blob.acl.save()
 
     # set and save OWNER access for suitable_group on json object (gsutil ach ch -g suitable_group:O)
-    blob.acl.user(suitable_group).grant_owner()
+    blob.acl.group(suitable_group).grant_owner()
     blob.acl.save()
 
     print("Banner action complete.")
@@ -94,11 +94,13 @@ if __name__ == '__main__':
 
     # if custom banner
     if args.json:
+        # convert file to string, post banner
         convert_json_to_string(args.json, args.env)
-
-    # if "--delete", remove banner
-    if args.delete:
-        delete_banner(args.env)
-    # if not "--delete", post banner
+    # if not custom banner
     else:
-        post_banner(args.env)
+        # if "--delete" (remove banner)
+        if args.delete:
+            delete_banner(args.env)
+        # if not "--delete" (post banner)
+        else:
+            post_banner(args.env)


### PR DESCRIPTION
In the event of a Service Incident related to the Terra UI, SDLC notes that a message must be posted to the platform for users to be made aware of the ongoing issue. The messaging is provided to users of the platform with a modifiable banner.The process of posting the banner has a few steps that are manual but this python script provides a streamlined solution for internal members that are on a suitability roster.