### PR TITLE
Expand the setup instructions for the Cloud Functions example.

### DIFF
--- a/scripts/launch_workflow_cf/README.md
+++ b/scripts/launch_workflow_cf/README.md
@@ -1,28 +1,122 @@
-## launch_workflow CF
-The scripts in this directory can be used to deploy a Google Cloud Function (CF) that launches a Terra workflow, triggered off of a file being uploaded to a GCP bucket.
+# launch_workflow Cloud Function
 
-Before running `deploy_local.sh`, you must perform these manual steps:
-1. Create or identify the GCP project where this CF will live / be billed  
-  a. Enable the Cloud Functions API by visiting `https://console.developers.google.com/apis/library/cloudfunctions.googleapis.com?project=<your_project_name>`  
-  b. Enable the Cloud Build API by visiting `https://console.developers.google.com/apis/library/cloudbuild.googleapis.com?project=<your_project_name>`
-  c. Enable IAM Service Account Credentials API by visiting `https://console.developers.google.com/apis/library/iamcredentials.googleapis.com?project=<your_project_name>`
-  d. Enable Secret Manager `https://console.cloud.google.com/marketplace/product/google/secretmanager.googleapis.com`
-2. Create or identify the bucket in that project that will be used for files to trigger the CF, e.g. `launch-workflow-test-input`
-3. Create a GCP service account 
-  a. create a SA key (json file), upload it to Secret Manager with the name `service_account_key`, and grant the SA `Secret Manager Secret Accessor` permissions
-4. Register the service account in Terra -  see https://github.com/broadinstitute/terra-tools/tree/master/scripts/register_service_account
-5. Retrieve the proxy group for the service account using this swagger endpoint: https://api.firecloud.org/#/Profile/getProxyGroup
-    a. Grant that SA's proxy group `Storage Object Viewer` permissions to the input bucket
-    b. If your workflow uses a private container image, also grant the SA's proxy group `Storage Object Viewer` permissions to the `artifacts.<project-id>.appspot.com` bucket
-6. Share the Terra workspace with the SA, granting Writer & compute access.
-7. Update the `config.yaml` file in this directory with the Terra workspace and workflow information you want to use, including the name of the workflow input that needs to be updated with the file information from the file that triggers each CF run.
+The scripts in this directory can be used to deploy a Google Cloud Function (CF) that launches a Terra workflow. The Cloud Function is triggered when a file is created or modified in a specific Google Cloud Storage bucket.
 
-These values will be used as input parameters to the deployment script.
+Note: this example is specificaly written assumming:
 
-Usage:
+* the triggering file is an input parameter to the Terra workflow
+* the most recently created entity set should be used, or override this default via `ENTITY_SET_TO_USE`
+* the Terra UI is used to control *all other aspects* of the workflow configuration, such as:
+  * which version of the method is to be used
+  * whether call caching is enabled
+  * whether to delete intermediate outputs
+  * the type of the root entity
+  * how the columns of the root entity map onto the workflow parameters
 
-```./deploy_local.sh PROJECT BUCKET SERVICE_ACCOUNT```
+**New to Cloud Functions and Secret Manager?** Don't start here. Instead see:
 
+* [Python Quickstart | Cloud Functions Documentation | Google Cloud](http://cloud/functions/docs/quickstart-python)
+* [Quickstart | Secret Manager Documentation | Google Cloud](http://cloud/secret-manager/docs/quickstart)
+
+**New to Terra groups and permssions?** Don't start here. Instead see:
+
+* [Pet accounts and proxy groups – Terra Support](https://support.terra.bio/hc/en-us/articles/360031023592-Understanding-and-setting-up-a-proxy-group)
+* [Accessing advanced GCP features in Terra – Terra Support](https://support.terra.bio/hc/en-us/articles/360051229072)
+
+# Setup
+
+## Configure the Terra Workflow
+
+1. Create or identify the Terra workflow you want to trigger via a Cloud Function.
+    * For a simple example, see [example.wdl](./example.wdl).
+1. Upload an entity set of all but one of the parameters for your workflow. The one parameter absent from the entity set should be the one that is the path to the Cloud Storage file that will trigger the workflow.
+    * Create this entity set even if the set would only contain one entity (one row of parameter values).
+    * For a simple example, see [example.tsv](./example.tsv).
+1. **IMPORTANT** Make sure you have used the Terra User Interface to run your workflow successfully at least once using the entity set.
+
+## Configure the Cloud and Terra execution environments
+
+1. Create or identify the Google Cloud Platform project where this Cloud Function will live / be billed.
+    1. Enable the [Cloud Functions API](https://console.developers.google.com/apis/library/cloudfunctions.googleapis.com) for that project.
+    1. Enable the [Secret Manager API](https://console.cloud.google.com/marketplace/product/google/secretmanager.googleapis.com) for that project.
+    1. Enable the [Cloud Build API](https://console.developers.google.com/apis/library/cloudbuild.googleapis.com) for this project.
+1. Create or identify the bucket in that project that will be used for files to trigger the Cloud Function.
+1. Create a new [service account](https://console.cloud.google.com/iam-admin/serviceaccounts) within that project. It will look like `<your service account name>@<your project id>.iam.gserviceaccount.com`.
+1. Downlad a JSON key for the newly created service account and store it in a safe place.
+1. Upload the JSON key to [Secret Manager](https://console.cloud.google.com/security/secret-manager).
+1. For the newly created secret, in column "Actions", choose "Copy Resource ID". You'll need this value for the deployment step and it will look like: `projects/<your project number>/secrets/<your secret name>/versions/1`.
+1. Give the service account the needed permissions to items within the project.
+    1. Grant role `Secret Manager Secret Accessor` to the service account.
+    1. Grant role `Storage Object Viewer` to the service account on the bucket that will trigger the Cloud Function.
+1. [Register the service account](https://github.com/broadinstitute/terra-tools/tree/master/scripts/register_service_account) in Terra.
+1. [Create a new Terra group](https://app.terra.bio/#groups) to hold only the service account. It will look like `
+<your groupname>@firecloud.org`.
+1. Give the Terra Group the needed permissions to items within the project.
+    1. Add the Terra group to the billing project (a.k.a. workspace namespace).
+    1. Grant role `Storage Object Viewer` to the Terra group on the bucket that will trigger the Cloud Function. This is because, presumably, the workflow will need to read the contents of the file that triggered the workflow.
+    1. If your workflow uses a private Google Container Repository image, also grant role `Storage Object Viewer` to the Terra group on the bucket that holds the image (e.g., `artifacts.<your project id>.appspot.com`).
+1. Give the Terra Group the needed permissions within Terra.
+    1. Share the Terra workspace with the Terra group, granting "Writer" and "Can compute" access.
+    1. If the workspace has an Authorization Domain, ensure that the Terra group is a member of the Authorization Domain.
+1. If the workflow method is private, share the workflow method. Note that for the Broad Methods repository, sharing with groups is not yet supported. Instead share the method with the service account.
+
+# Deploy
+
+## Deploy the Cloud Function
+
+1. Update the `config.yaml` file in this directory with the Terra workspace and workflow information you want to use. These values will be used as environment variable inputs to the deployment script.
+2. Run the deployment script. Usage:
+```
+./deploy_cloud_function.sh PROJECT BUCKET SERVICE_ACCOUNT
+```
 e.g.
+```
+./deploy_cloud_function.sh launch-workflow-test launch-workflow-test-input \
+    launch-workflow-sa@launch-workflow-test.iam.gserviceaccount.com
+```
 
-```./deploy_local.sh launch-workflow-test launch-workflow-test-input launch-workflow-sa@launch-workflow-test.iam.gserviceaccount.com```
+# Test
+
+## Test the Cloud Function trigger
+
+Test the cloud function by placing a file in the bucket to trigger the workflow. You can do this using the [cloud console](https://console.cloud.google.com/storage/browser/) or with the following script:
+```
+./test_cloud_function.sh BUCKET
+```
+e.g.
+```
+./test_cloud_function.sh launch-workflow-test-input
+```
+
+## [Optional] Run the Cloud Function code locally.
+
+This is useful for rapid debugging of permissions or other issues.
+
+1. Create a [virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) for Python 3.
+```
+# Tip: run this outside of your git clone, such as under ${HOME}/my-venvs
+cd path/to/where/I/keep/my/venvs
+python3 -m venv test-cf-env
+```
+2. Activate the [virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment).
+```
+source test-cf-env/bin/activate
+```
+3. Install the dependencies.
+```
+# Run this from directory scripts/launch_workflow_cf in your clone.
+pip3 install -r requirements.txt
+```
+4. Invoke the workflow manually.
+```
+# Run this from directory scripts/launch_workflow_cf in your clone.
+
+export WORKSPACE_NAMESPACE="morgan-fieldeng"
+export WORKSPACE_NAME="launch-workflow-test"
+export METHOD_NAMESPACE="morgan-fieldeng"
+export METHOD_NAME="hello-world-plus-prefixes"
+export TRIGGER_PARAMETER_NAME="MyWorkflowName.aCloudStorageFilePath"
+export SECRET_PATH="/local/filepath/to/service-account-key.json"
+
+python3 main.py
+```

--- a/scripts/launch_workflow_cf/README.md
+++ b/scripts/launch_workflow_cf/README.md
@@ -2,10 +2,10 @@
 
 The scripts in this directory can be used to deploy a Google Cloud Function (CF) that launches a Terra workflow. The Cloud Function is triggered when a file is created or modified in a specific Google Cloud Storage bucket.
 
-Note: this example is specificaly written assumming:
+Note: this example is specifically written assuming:
 
 * the triggering file is an input parameter to the Terra workflow
-* the most recently created entity set should be used, or override this default via `ENTITY_SET_TO_USE`
+* the most recently created entity set should be used, or override this default via `ENTITY_SET_NAME`
 * the Terra UI is used to control *all other aspects* of the workflow configuration, such as:
   * which version of the method is to be used
   * whether call caching is enabled
@@ -18,7 +18,7 @@ Note: this example is specificaly written assumming:
 * [Python Quickstart | Cloud Functions Documentation | Google Cloud](http://cloud/functions/docs/quickstart-python)
 * [Quickstart | Secret Manager Documentation | Google Cloud](http://cloud/secret-manager/docs/quickstart)
 
-**New to Terra groups and permssions?** Don't start here. Instead see:
+**New to Terra groups and permissions?** Don't start here. Instead see:
 
 * [Pet accounts and proxy groups – Terra Support](https://support.terra.bio/hc/en-us/articles/360031023592-Understanding-and-setting-up-a-proxy-group)
 * [Accessing advanced GCP features in Terra – Terra Support](https://support.terra.bio/hc/en-us/articles/360051229072)
@@ -42,7 +42,7 @@ Note: this example is specificaly written assumming:
     1. Enable the [Cloud Build API](https://console.developers.google.com/apis/library/cloudbuild.googleapis.com) for this project.
 1. Create or identify the bucket in that project that will be used for files to trigger the Cloud Function.
 1. Create a new [service account](https://console.cloud.google.com/iam-admin/serviceaccounts) within that project. It will look like `<your service account name>@<your project id>.iam.gserviceaccount.com`.
-1. Downlad a JSON key for the newly created service account and store it in a safe place.
+1. Download a JSON key for the newly created service account and store it in a safe place.
 1. Upload the JSON key to [Secret Manager](https://console.cloud.google.com/security/secret-manager).
 1. For the newly created secret, in column "Actions", choose "Copy Resource ID". You'll need this value for the deployment step and it will look like: `projects/<your project number>/secrets/<your secret name>/versions/1`.
 1. Give the service account the needed permissions to items within the project.
@@ -50,13 +50,13 @@ Note: this example is specificaly written assumming:
     1. Grant role `Storage Object Viewer` to the service account on the bucket that will trigger the Cloud Function.
 1. [Register the service account](https://github.com/broadinstitute/terra-tools/tree/master/scripts/register_service_account) in Terra.
 1. [Create a new Terra group](https://app.terra.bio/#groups) to hold only the service account. It will look like `
-<your groupname>@firecloud.org`.
+<your group name>@firecloud.org`.
 1. Give the Terra Group the needed permissions to items within the project.
     1. Add the Terra group to the billing project (a.k.a. workspace namespace).
     1. Grant role `Storage Object Viewer` to the Terra group on the bucket that will trigger the Cloud Function. This is because, presumably, the workflow will need to read the contents of the file that triggered the workflow.
     1. If your workflow uses a private Google Container Repository image, also grant role `Storage Object Viewer` to the Terra group on the bucket that holds the image (e.g., `artifacts.<your project id>.appspot.com`).
 1. Give the Terra Group the needed permissions within Terra.
-    1. Share the Terra workspace with the Terra group, granting "Writer" and "Can compute" access.
+    1. Share the Terra workspace with the Terra group, granting `Writer` and `Can compute` access.
     1. If the workspace has an Authorization Domain, ensure that the Terra group is a member of the Authorization Domain.
 1. If the workflow method is private, share the workflow method. Note that for the Broad Methods repository, sharing with groups is not yet supported. Instead share the method with the service account.
 

--- a/scripts/launch_workflow_cf/config.yaml
+++ b/scripts/launch_workflow_cf/config.yaml
@@ -1,6 +1,7 @@
 ---
-WORKSPACE_NAME: launch-workflow-test
 WORKSPACE_NAMESPACE: morgan-fieldeng
-WORKFLOW_NAME: hello-world-plus-prefixes
-WORKFLOW_NAMESPACE: morgan-fieldeng
-INPUT_NAME: input_file
+WORKSPACE_NAME: launch-workflow-test
+METHOD_NAMESPACE: morgan-fieldeng
+METHOD_NAME: hello-world-plus-prefixes
+SECRET_PATH: projects/<project number>/secrets/<secret name>/versions/1
+TRIGGER_PARAMETER_NAME: MyWorkflowName.aCloudStorageFilePath

--- a/scripts/launch_workflow_cf/deploy_cloud_function.sh
+++ b/scripts/launch_workflow_cf/deploy_cloud_function.sh
@@ -7,7 +7,7 @@ BUCKET=$2
 SERVICE_ACCOUNT=$3
 
 if [ $# -lt 3 ]; then
-    echo "USAGE: ./deploy_local.sh PROJECT BUCKET SERVICE_ACCOUNT"
+    echo "USAGE: ./deploy_cloud_function.sh PROJECT BUCKET SERVICE_ACCOUNT"
     exit 1
 fi
 
@@ -25,4 +25,3 @@ gcloud alpha functions deploy "${FUNCTION}" \
   --trigger-event="google.storage.object.finalize" \
   --trigger-resource="${BUCKET}" \
   -q
-

--- a/scripts/launch_workflow_cf/example.tsv
+++ b/scripts/launch_workflow_cf/example.tsv
@@ -1,0 +1,4 @@
+entity:job_id	aStringParameter	aStringArrayParameter	aNumericParameter
+job_1	one	o, n, e	1
+job_2	two	t, w, o	2
+job_3	three	t, h, r, e, e	3

--- a/scripts/launch_workflow_cf/example.wdl
+++ b/scripts/launch_workflow_cf/example.wdl
@@ -1,0 +1,60 @@
+version 1.0
+
+# Example WDL for testing run via Cloud Function.
+
+workflow MyWorkflowName {
+  input {
+    String aStringParameter
+    Array[String] aStringArrayParameter
+    Int aNumericParameter
+    String aCloudStorageFilePath
+  }
+
+  call MyTaskName {
+    input:
+      aStringParameter = aStringParameter,
+      aStringArrayParameter = aStringArrayParameter,
+      aNumericParameter = aNumericParameter,
+      aCloudStorageFilePath = aCloudStorageFilePath
+  }
+}
+
+#-------------------------------------------------------------------------------
+task MyTaskName {
+  input {
+    String aStringParameter
+    Array[String] aStringArrayParameter
+    Int aNumericParameter
+    String aCloudStorageFilePath
+  }
+
+  String statusOutputFilename = "workflow_status.txt"
+
+  command {
+    set -o xtrace
+    # For any command failures in this script, return the error.
+    set -o errexit
+    set -o pipefail
+    set -o nounset
+
+    # Make a file with all params.
+    echo aStringParameter: "${aStringParameter}" > results.txt
+    echo aStringArrayParameter: "${sep=',' aStringArrayParameter}" >> results.txt
+    echo aNumericParameter: "${aNumericParameter}" >> results.txt
+    echo aCloudStorageFilePath: "${aCloudStorageFilePath}" >> results.txt
+
+    echo As part of the test, run wordcount on the file that triggered the workflow. >> results.txt
+    gsutil cat "${aCloudStorageFilePath}" | wc >> results.txt
+
+    # Place details for the workflow provenance in the workspace bucket.
+    cp results.txt "${statusOutputFilename}"
+  }
+
+  output {
+    File statusOutputFile = "${statusOutputFilename}"
+  }
+
+  runtime {
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+  }
+}

--- a/scripts/launch_workflow_cf/main.py
+++ b/scripts/launch_workflow_cf/main.py
@@ -1,103 +1,83 @@
-"""Google Cloud Function to launch a workflow."""
+"""Google Cloud Function to launch a Terra workflow."""
 
 import os
-
-from utils import get_access_token, check_fapi_response, get_workspace_config, \
-    get_entities, update_workspace_config, create_submission
-
-
-# read config variables from env
-WORKSPACE_NAME = os.environ.get("WORKSPACE_NAME")
-WORKSPACE_NAMESPACE = os.environ.get("WORKSPACE_NAMESPACE")
-WORKFLOW_NAME = os.environ.get("WORKFLOW_NAME")
-WORKFLOW_NAMESPACE = os.environ.get("WORKFLOW_NAMESPACE")
-INPUT_NAME = os.environ.get("INPUT_NAME")
+import tensorflow as tf
+from typing import Any, Dict
+from utils import prepare_and_launch
 
 
-def prepare_and_launch(file_path):
-    # get access token and input to headers for requests
-    headers = {"Authorization" : "bearer " + get_access_token()}
+def launch_workflow(data: Dict[Any, Any], context: Any):
+  """Entry point for execution via a Cloud Function.
 
-    # get the workflow config
-    workflow = get_workspace_config(
-        WORKSPACE_NAMESPACE,
-        WORKSPACE_NAME,
-        WORKFLOW_NAMESPACE,
-        WORKFLOW_NAME,
-        headers
-    )
-    check_fapi_response(workflow, 200)
-    workflow_config_json = workflow.json()
+    This Cloud Function reads configuration from environment variables and the triggering event.
 
-    # This workflow uses inputs from the data table as well as the file_path 
-    # value input to this function. We first pull the root entity type from 
-    # the workflow config, and then look for sets of that entity type, 
-    # selecting the first set found in the data table.
-    root_entity_type = workflow_config_json['rootEntityType']
+    This example workflow uses entities from a data table so that workflow parameter values do
+    not need to be hardcoded here in this script. But if you do want to hardcode values for the
+    other parameters, follow the pattern in the code example below for correct escaping. Use a
+    'for loop' if you wish to execute concurrent jobs in a parameter-parallel manner.
 
-    expression = f'this.{root_entity_type}s'
-    set_entity_type = f'{root_entity_type}_set'
-    entities = get_entities(WORKSPACE_NAMESPACE, WORKSPACE_NAME, set_entity_type, headers)
-    check_fapi_response(entities, 200)
-    all_set_names = [ent['name'] for ent in entities.json()]
-    set_to_use = all_set_names[0]  # use the first set
+    # Note: All parameter values must be of type string in the json.
+    # WDL parameter of type 'String' must be surrounded by an extra set of quotes.
+    # WDL parameter of type 'Array[String]' must be surrounded by square brackets.
+    a_string_value = "example"
+    a_string_array_value = ["one", "two", "three"]
+    a_boolean_value = True
+    a_numeric_value = 42
+    workflow_parameters = {
+        "MyWorkflowOrTaskName.aStringParameter": f"\"{a_string_value}\"",
+        "MyWorkflowOrTaskName.aStringArrayParameter": "[\"" + "\", \"".join(a_string_array_value) + "\"]",
+        "MyWorkflowOrTaskName.aNumericParameter": f"{a_numeric_value}",
+    }
 
-    # Next we need to add the specific input from file_path. We update this value
-    # in the inputs section of the workflow_config_json.
-    for input_value in workflow_config_json['inputs']:
-        if input_value.endswith(INPUT_NAME):
-            workflow_config_json['inputs'][input_value] = f"\"{file_path}\""
+    Environment variables:
+      WORKSPACE_NAMESPACE: The project id of the Terra billing project in which the workspace resides.
+      WORKSPACE_NAME: The name of the workspace in which the workflow resides
+      METHOD_NAMESPACE: The namespace of the workflow method.
+      METHOD_NAME: The name of the workflow method.
+      SECRET_PATH: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
+        testing locally, the filepath to the json key for the service account.
+      TRIGGER_PARAMETER_NAME: The name of the workflow parameter to receive the path to the triggering file.
+        Defaults to `MyWorkflowName.aCloudStorageFilePath`.
+      ENTITY_SET_NAME: The name of the entity set to be used for all other workflow parameters. Defaults to
+        the most recently created entity set of the root entity type.
 
-    # remove outputs assignment from config
-    workflow_config_json['outputs'] = {}
+    Args:
+      event:  The dictionary with data specific to this type of event.
+              The `data` field contains a description of the event in
+              the Cloud Storage `object` format described here:
+              https://cloud.google.com/storage/docs/json_api/v1/objects#resource
+      context: Metadata of triggering event.
+    Returns:
+      None; the side effect is the execution of a parameter-parallel Terra workflow.
+  """
 
-    # update the workflow configuration
-    updated_workflow = update_workspace_config(
-        WORKSPACE_NAMESPACE,
-        WORKSPACE_NAME,
-        WORKFLOW_NAMESPACE,
-        WORKFLOW_NAME,
-        workflow_config_json,
-        headers
-    )
-    check_fapi_response(updated_workflow, 200)
+  # Extract file information from the triggering PubSub message.
+  file_name = data.get('name')
+  bucket_name = data.get('bucket')
+  file_path = f"gs://{bucket_name}/{file_name}"
+  print(f"input file: {file_name}; full path: {file_path}")
+  # Default to the parameter name from the example workflow.
+  workflow_parameters = {
+      os.getenv("TRIGGER_PARAMETER_NAME", "MyWorkflowName.aCloudStorageFilePath"): f"\"{file_path}\"",
+      }
 
-    # launch the workflow
-    create_submisson_response = create_submission(
-        WORKSPACE_NAMESPACE,
-        WORKSPACE_NAME,
-        WORKFLOW_NAMESPACE,
-        WORKFLOW_NAME,
-        headers,
-        use_callcache=True,
-        entity=set_to_use,
-        etype=set_entity_type,
-        expression=expression
-    )
-    check_fapi_response(create_submisson_response, 201)
-
-    submission_id = create_submisson_response.json()['submissionId']
-    print(f"Successfully created submission: submissionId = {submission_id}.")
-
-
-def launch_workflow(data, context):
-    # extract file information from the triggering PubSub message
-    file_name = data.get('name')
-    bucket_name = data.get('bucket')
-    file_path = f"gs://{bucket_name}/{file_name}"
-
-    print(f"input file: {file_name}; full path: {file_path}")
-
-    prepare_and_launch(file_path)
+  prepare_and_launch(
+      workspace_namespace=os.getenv("WORKSPACE_NAMESPACE"),
+      workspace_name=os.getenv("WORKSPACE_NAME"),
+      method_namespace=os.getenv("METHOD_NAMESPACE"),
+      method_name=os.getenv("METHOD_NAME"),
+      secret_path=os.getenv("SECRET_PATH"),
+      workflow_parameters=workflow_parameters,
+      # Default to the most recently created entity set.
+      entity_set_name=os.getenv("ENTITY_SET_NAME", None)
+      )
 
 
 if __name__ == "__main__":
+  """Entry point of manual execution for testing purposes."""
 
-    WORKSPACE_NAME = "launch-workflow-test"
-    WORKSPACE_NAMESPACE = "morgan-fieldeng"
-    WORKFLOW_NAME = "hello-world-plus-prefixes"
-    WORKFLOW_NAMESPACE = "morgan-fieldeng"
-    INPUT_NAME = "input_file"
-
-    file_path = "gs://launch-workflow-test-input/test.txt"
-    prepare_and_launch(file_path)
+  # This example parameter is a world-readable file.
+  # gs://genomics-public-data/platinum-genomes/other/platinum_genomes_sample_info.csv
+  launch_workflow(data={"bucket": "genomics-public-data",
+                        "name": "platinum-genomes/other/platinum_genomes_sample_info.csv"},
+                  context=None)

--- a/scripts/launch_workflow_cf/main.py
+++ b/scripts/launch_workflow_cf/main.py
@@ -1,68 +1,67 @@
 """Google Cloud Function to launch a Terra workflow."""
 
 import os
-import tensorflow as tf
 from typing import Any, Dict
 from utils import prepare_and_launch
 
 
 def launch_workflow(data: Dict[Any, Any], context: Any):
-  """Entry point for execution via a Cloud Function.
+    """Entry point for execution via a Cloud Function.
 
-    This Cloud Function reads configuration from environment variables and the triggering event.
+      This Cloud Function reads configuration from environment variables and the triggering event.
 
-    This example workflow uses entities from a data table so that workflow parameter values do
-    not need to be hardcoded here in this script.
+      This example workflow uses entities from a data table so that workflow parameter values do
+      not need to be hardcoded here in this script.
 
-    Environment variables:
-      WORKSPACE_NAMESPACE: The project id of the Terra billing project in which the workspace resides.
-      WORKSPACE_NAME: The name of the workspace in which the workflow resides
-      METHOD_NAMESPACE: The namespace of the workflow method.
-      METHOD_NAME: The name of the workflow method.
-      SECRET_PATH: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
-        testing locally, the filepath to the JSON key for the service account.
-      TRIGGER_PARAMETER_NAME: The name of the workflow parameter to receive the path to the triggering file.
-        Defaults to `MyWorkflowName.aCloudStorageFilePath`.
-      ENTITY_SET_NAME: The name of the entity set to be used for all other workflow parameters. Defaults to
-        the most recently created entity set of the root entity type.
+      Environment variables:
+        WORKSPACE_NAMESPACE: The project id of the Terra billing project in which the workspace resides.
+        WORKSPACE_NAME: The name of the workspace in which the workflow resides
+        METHOD_NAMESPACE: The namespace of the workflow method.
+        METHOD_NAME: The name of the workflow method.
+        SECRET_PATH: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
+          testing locally, the filepath to the JSON key for the service account.
+        TRIGGER_PARAMETER_NAME: The name of the workflow parameter to receive the path to the triggering file.
+          Defaults to `MyWorkflowName.aCloudStorageFilePath`.
+        ENTITY_SET_NAME: The name of the entity set to be used for all other workflow parameters. Defaults to
+          the most recently created entity set of the root entity type.
 
-    Args:
-      event:  The dictionary with data specific to this type of event.
-              The `data` field contains a description of the event in
-              the Cloud Storage `object` format described here:
-              https://cloud.google.com/storage/docs/json_api/v1/objects#resource
-      context: Metadata of triggering event.
-    Returns:
-      None; the side effect is the execution of a parameter-parallel Terra workflow.
-  """
+      Args:
+        event:  The dictionary with data specific to this type of event.
+                The `data` field contains a description of the event in
+                the Cloud Storage `object` format described here:
+                https://cloud.google.com/storage/docs/json_api/v1/objects#resource
+        context: Metadata of triggering event.
+      Returns:
+        None; the side effect is the execution of a parameter-parallel Terra workflow.
+    """
 
-  # Extract file information from the triggering PubSub message.
-  file_name = data.get('name')
-  bucket_name = data.get('bucket')
-  file_path = f"gs://{bucket_name}/{file_name}"
-  print(f"input file: {file_name}; full path: {file_path}")
-  # Default to the parameter name from the example workflow.
-  workflow_parameters = {
-      os.getenv("TRIGGER_PARAMETER_NAME", "MyWorkflowName.aCloudStorageFilePath"): f"\"{file_path}\"",
-      }
+    # Extract file information from the triggering PubSub message.
+    file_name = data.get('name')
+    bucket_name = data.get('bucket')
+    file_path = f"gs://{bucket_name}/{file_name}"
+    print(f"input file: {file_name}; full path: {file_path}")
+    # Default to the parameter name from the example workflow.
+    workflow_parameters = {
+        os.getenv("TRIGGER_PARAMETER_NAME", "MyWorkflowName.aCloudStorageFilePath"): f"\"{file_path}\"",
+        }
 
-  prepare_and_launch(
-      workspace_namespace=os.getenv("WORKSPACE_NAMESPACE"),
-      workspace_name=os.getenv("WORKSPACE_NAME"),
-      method_namespace=os.getenv("METHOD_NAMESPACE"),
-      method_name=os.getenv("METHOD_NAME"),
-      secret_path=os.getenv("SECRET_PATH"),
-      workflow_parameters=workflow_parameters,
-      # Default to 'None', which will cause the most recently created entity set to be used.
-      entity_set_name=os.getenv("ENTITY_SET_NAME", None)
-      )
+    prepare_and_launch(
+        workspace_namespace=os.getenv("WORKSPACE_NAMESPACE"),
+        workspace_name=os.getenv("WORKSPACE_NAME"),
+        method_namespace=os.getenv("METHOD_NAMESPACE"),
+        method_name=os.getenv("METHOD_NAME"),
+        secret_path=os.getenv("SECRET_PATH"),
+        workflow_parameters=workflow_parameters,
+        # Default to 'None', which will cause the most recently created entity set to be used.
+        entity_set_name=os.getenv("ENTITY_SET_NAME", None)
+        )
 
 
 if __name__ == "__main__":
-  """Entry point of manual execution for testing purposes."""
+    """Entry point of manual execution for testing purposes."""
 
-  # This example parameter is a world-readable file.
-  # gs://genomics-public-data/platinum-genomes/other/platinum_genomes_sample_info.csv
-  launch_workflow(data={"bucket": "genomics-public-data",
-                        "name": "platinum-genomes/other/platinum_genomes_sample_info.csv"},
-                  context=None)
+    # This example parameter is a world-readable file.
+    # gs://genomics-public-data/platinum-genomes/other/platinum_genomes_sample_info.csv
+    launch_workflow(data={"bucket": "genomics-public-data",
+                          "name": "platinum-genomes/other/platinum_genomes_sample_info.csv"},
+                    context=None)

--- a/scripts/launch_workflow_cf/main.py
+++ b/scripts/launch_workflow_cf/main.py
@@ -12,22 +12,7 @@ def launch_workflow(data: Dict[Any, Any], context: Any):
     This Cloud Function reads configuration from environment variables and the triggering event.
 
     This example workflow uses entities from a data table so that workflow parameter values do
-    not need to be hardcoded here in this script. But if you do want to hardcode values for the
-    other parameters, follow the pattern in the code example below for correct escaping. Use a
-    'for loop' if you wish to execute concurrent jobs in a parameter-parallel manner.
-
-    # Note: All parameter values must be of type string in the json.
-    # WDL parameter of type 'String' must be surrounded by an extra set of quotes.
-    # WDL parameter of type 'Array[String]' must be surrounded by square brackets.
-    a_string_value = "example"
-    a_string_array_value = ["one", "two", "three"]
-    a_boolean_value = True
-    a_numeric_value = 42
-    workflow_parameters = {
-        "MyWorkflowOrTaskName.aStringParameter": f"\"{a_string_value}\"",
-        "MyWorkflowOrTaskName.aStringArrayParameter": "[\"" + "\", \"".join(a_string_array_value) + "\"]",
-        "MyWorkflowOrTaskName.aNumericParameter": f"{a_numeric_value}",
-    }
+    not need to be hardcoded here in this script.
 
     Environment variables:
       WORKSPACE_NAMESPACE: The project id of the Terra billing project in which the workspace resides.
@@ -35,7 +20,7 @@ def launch_workflow(data: Dict[Any, Any], context: Any):
       METHOD_NAMESPACE: The namespace of the workflow method.
       METHOD_NAME: The name of the workflow method.
       SECRET_PATH: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
-        testing locally, the filepath to the json key for the service account.
+        testing locally, the filepath to the JSON key for the service account.
       TRIGGER_PARAMETER_NAME: The name of the workflow parameter to receive the path to the triggering file.
         Defaults to `MyWorkflowName.aCloudStorageFilePath`.
       ENTITY_SET_NAME: The name of the entity set to be used for all other workflow parameters. Defaults to
@@ -68,7 +53,7 @@ def launch_workflow(data: Dict[Any, Any], context: Any):
       method_name=os.getenv("METHOD_NAME"),
       secret_path=os.getenv("SECRET_PATH"),
       workflow_parameters=workflow_parameters,
-      # Default to the most recently created entity set.
+      # Default to 'None', which will cause the most recently created entity set to be used.
       entity_set_name=os.getenv("ENTITY_SET_NAME", None)
       )
 

--- a/scripts/launch_workflow_cf/requirements.txt
+++ b/scripts/launch_workflow_cf/requirements.txt
@@ -1,5 +1,4 @@
 firecloud==0.16.25
-gcs-oauth2-boto-plugin==2.5
 google-cloud-secret-manager==0.2.0
-google-cloud-storage==1.26.0
-oauth2client==4.1.3
+oauth2client
+tensorflow

--- a/scripts/launch_workflow_cf/requirements.txt
+++ b/scripts/launch_workflow_cf/requirements.txt
@@ -1,4 +1,3 @@
 firecloud==0.16.25
 google-cloud-secret-manager==0.2.0
 oauth2client
-tensorflow

--- a/scripts/launch_workflow_cf/test_cloud_function.sh
+++ b/scripts/launch_workflow_cf/test_cloud_function.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $# -lt 1 ]; then
-    echo "USAGE: ./test_local.sh BUCKET"
+    echo "USAGE: ./test_cloud_function.sh BUCKET"
     exit 1
 fi
 

--- a/scripts/launch_workflow_cf/utils.py
+++ b/scripts/launch_workflow_cf/utils.py
@@ -14,159 +14,161 @@ from oauth2client.service_account import ServiceAccountCredentials
 
 def prepare_and_launch(workspace_namespace, workspace_name, method_namespace, method_name,
                        secret_path, workflow_parameters, entity_set_name=None):
-  """Launch a Terra workflow programmatically.
+    """Launch a Terra workflow programmatically.
 
-    Arguments `workflow_parameters` and `entity_set_name` are used to specify the parameters to the
-    workflow. The Terra UI is used to control *all other aspects* of the workflow configuration, such as:
-    * which version of the method is to be used
-    * whether call caching is enabled
-    * whether to delete intermediate outputs
-    * the type of the root entity
-    * how the columns of the root entity map onto the workflow parameters
+      Arguments `workflow_parameters` and `entity_set_name` are used to specify the parameters to the
+      workflow. The Terra UI is used to control *all other aspects* of the workflow configuration, such as:
+      * which version of the method is to be used
+      * whether call caching is enabled
+      * whether to delete intermediate outputs
+      * the type of the root entity
+      * how the columns of the root entity map onto the workflow parameters
 
-    Args:
-      workspace_namespace: The project id of the Terra billing project in which the workspace resides.
-      workspace_name: The name of the workspace in which the workflow resides.
-      method_namespace: The namespace of the workflow method.
-      method_name: The name of the workflow method.
-      secret_path: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
-        testing locally, the filepath to the json key for the service account.
-      workflow_parameters: A dictionary of key/value pairs to merge with the inputs from the workflow configuration,
-        overwriting any duplicate keys.
-      entity_set_name: The name of the entity set to be used for all other workflow parameters. Defaults to
-        the most recently created entity set of the root entity type.
-    Returns:
-      None; the side effect is the execution of a parameter-parallel Terra workflow.
-  """
-  # Get access token and and add to headers for requests.
-  headers = {"Authorization": "bearer " + get_access_token(secret_path=secret_path)}
+      Args:
+        workspace_namespace: The project id of the Terra billing project in which the workspace resides.
+        workspace_name: The name of the workspace in which the workflow resides.
+        method_namespace: The namespace of the workflow method.
+        method_name: The name of the workflow method.
+        secret_path: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
+          testing locally, the filepath to the json key for the service account.
+        workflow_parameters: A dictionary of key/value pairs to merge with the inputs from the workflow configuration,
+          overwriting any duplicate keys.
+        entity_set_name: The name of the entity set to be used for all other workflow parameters. Defaults to
+          the most recently created entity set of the root entity type.
+      Returns:
+        None; the side effect is the execution of a parameter-parallel Terra workflow.
+    """
+    # Get access token and and add to headers for requests.
+    headers = {"Authorization": "bearer " + get_access_token(secret_path=secret_path)}
 
-  # Get the workflow config.
-  workflow_config_response = get_workflow_method_config(
-      workspace_namespace=workspace_namespace,
-      workspace_name=workspace_name,
-      method_namespace=method_namespace,
-      method_name=method_name,
-      headers=headers
-  )
-  check_fapi_response(response=workflow_config_response, success_code=200)
-  print("Current default workflow configuration:\n", json.dumps(workflow_config_response.json(), indent=4))
+    # Get the workflow config.
+    workflow_config_response = get_workflow_method_config(
+        workspace_namespace=workspace_namespace,
+        workspace_name=workspace_name,
+        method_namespace=method_namespace,
+        method_name=method_name,
+        headers=headers
+    )
+    check_fapi_response(response=workflow_config_response, success_code=200)
+    print("Current default workflow configuration:\n", json.dumps(workflow_config_response.json(), indent=4))
 
-  # Merge the workflow inputs configured in the Terra UI with the items from 'workflow_parameters'
-  # in-place, overwriting existing keys.
-  workflow_config_json = workflow_config_response.json()
-  workflow_config_json["inputs"].update(workflow_parameters)
-  if not "rootEntityType" in workflow_config_json:
-    raise ValueError("""The current default workflow configuration does not have a root entity type specified.
-      Be sure to use the Terra UI at least once to successfully run the workflow with an entity set.""")
+    # Merge the workflow inputs configured in the Terra UI with the items from 'workflow_parameters'
+    # in-place, overwriting existing keys.
+    workflow_config_json = workflow_config_response.json()
+    workflow_config_json["inputs"].update(workflow_parameters)
+    if not "rootEntityType" in workflow_config_json:
+        raise ValueError("""The current default workflow configuration does not have a root entity type specified.
+          Be sure to use the Terra UI at least once to successfully run the workflow with an entity set.""")
 
-  # Configure the entity set to be used.
-  root_entity_type = workflow_config_json["rootEntityType"]
-  expression = f"this.{root_entity_type}s"
-  set_entity_type = f"{root_entity_type}_set"
-  entities_response = get_entities(
-      workspace_namespace=workspace_namespace,
-      workspace_name=workspace_name,
-      etype=set_entity_type,
-      headers=headers
-  )
-  check_fapi_response(entities_response, 200)
-  all_set_names = [ent['name'] for ent in entities_response.json()]
-  if entity_set_name:
-    if not entity_set_name in all_set_names:
-      raise ValueError(f"entity set '{entity_set_name}' is not a member of root entity type '{root_entity_type}'")
-  else:
-    entity_set_name = all_set_names[-1]  # Use the most recently created entity set.
+    # Configure the entity set to be used.
+    root_entity_type = workflow_config_json["rootEntityType"]
+    expression = f"this.{root_entity_type}s"
+    set_entity_type = f"{root_entity_type}_set"
+    entities_response = get_entities(
+        workspace_namespace=workspace_namespace,
+        workspace_name=workspace_name,
+        etype=set_entity_type,
+        headers=headers
+    )
+    check_fapi_response(entities_response, 200)
+    all_set_names = [ent['name'] for ent in entities_response.json()]
+    if not all_set_names:
+        raise ValueError(f"There are no entity sets of type {set_entity_type}.")
+    elif entity_set_name:
+        if not entity_set_name in all_set_names:
+            raise ValueError(f"entity set '{entity_set_name}' is not a member of root entity type '{root_entity_type}'")
+    else:
+        entity_set_name = all_set_names[-1]  # Use the most recently created entity set.
 
-  # Update the workflow configuration.
-  updated_workflow_response = update_workflow_method_config(
-      workspace_namespace=workspace_namespace,
-      workspace_name=workspace_name,
-      method_namespace=method_namespace,
-      method_name=method_name,
-      body=workflow_config_json,
-      headers=headers
-  )
-  check_fapi_response(response=updated_workflow_response, success_code=200)
+    # Update the workflow configuration.
+    updated_workflow_response = update_workflow_method_config(
+        workspace_namespace=workspace_namespace,
+        workspace_name=workspace_name,
+        method_namespace=method_namespace,
+        method_name=method_name,
+        body=workflow_config_json,
+        headers=headers
+    )
+    check_fapi_response(response=updated_workflow_response, success_code=200)
 
-  # Launch the workflow.
-  create_submisson_response = create_submission(
-      workspace_namespace=workspace_namespace,
-      workspace_name=workspace_name,
-      method_namespace=method_namespace,
-      method_name=method_name,
-      entity=entity_set_name,
-      etype=set_entity_type,
-      expression=expression,
-      headers=headers
-  )
-  print("Submission response:\n", json.dumps(create_submisson_response.json(), indent=4))
-  check_fapi_response(response=create_submisson_response, success_code=201)
-  submission_id = create_submisson_response.json()["submissionId"]
-  print(f"Successfully created submission: submissionId = {submission_id}.")
+    # Launch the workflow.
+    create_submisson_response = create_submission(
+        workspace_namespace=workspace_namespace,
+        workspace_name=workspace_name,
+        method_namespace=method_namespace,
+        method_name=method_name,
+        entity=entity_set_name,
+        etype=set_entity_type,
+        expression=expression,
+        headers=headers
+    )
+    print("Submission response:\n", json.dumps(create_submisson_response.json(), indent=4))
+    check_fapi_response(response=create_submisson_response, success_code=201)
+    submission_id = create_submisson_response.json()["submissionId"]
+    print(f"Successfully created submission: submissionId = {submission_id}.")
 
 def get_access_token(secret_path):
-  """Conditionally create an access token with the minimum necessary scopes.
+    """Conditionally create an access token with the minimum necessary scopes.
 
-  When run as a Cloud Function, a service account's JSON credentials file from Secret Manager
-  is used to populate the access token. When run locally, either the service account JSON key file or the
-  application default credential is used to populate the access token.
+    When run as a Cloud Function, a service account's JSON credentials file from Secret Manager
+    is used to populate the access token. When run locally, either the service account JSON key file or the
+    application default credential is used to populate the access token.
 
-  Args:
-    secret_path: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
-      testing locally, the filepath to the JSON key for the service account.
-  Returns:
-    An access token.
-  """
-  scopes = ["https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email"]
+    Args:
+      secret_path: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
+        testing locally, the filepath to the JSON key for the service account.
+    Returns:
+      An access token.
+    """
+    scopes = ["https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email"]
 
-  if not secret_path:  # Running locally as a user.
-    credentials = GoogleCredentials.get_application_default()
-    credentials = credentials.create_scoped(scopes)
-  elif os.path.isfile(secret_path):  # Running locally as the service account.
-    credentials = ServiceAccountCredentials.from_json_keyfile_name(secret_path, scopes=scopes)
-  else: # Running inside the Cloud Function.
-    # Retrieve the secret from the secret manager API.
-    client = SecretManagerServiceClient()
-    response = client.access_secret_version(secret_path)
-    service_account_key = response.payload.data.decode("utf-8")
-    json_acct_info = json.loads(service_account_key)
-    credentials = ServiceAccountCredentials.from_json_keyfile_dict(json_acct_info, scopes=scopes)
+    if not secret_path:  # Running locally as a user.
+        credentials = GoogleCredentials.get_application_default()
+        credentials = credentials.create_scoped(scopes)
+    elif os.path.isfile(secret_path):  # Running locally as the service account.
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(secret_path, scopes=scopes)
+    else: # Running inside the Cloud Function.
+        # Retrieve the secret from the secret manager API.
+        client = SecretManagerServiceClient()
+        response = client.access_secret_version(secret_path)
+        service_account_key = response.payload.data.decode("utf-8")
+        json_acct_info = json.loads(service_account_key)
+        credentials = ServiceAccountCredentials.from_json_keyfile_dict(json_acct_info, scopes=scopes)
 
-  return credentials.get_access_token().access_token
+    return credentials.get_access_token().access_token
 
 # Helper methods for Firecloud API calls. We cannot use the methods in firecloud.api because
 # we need to explicitly pass a header for auth.
 
 def check_fapi_response(response, success_code):
-  if response.status_code != success_code:
-    print(response.content)
-    raise FireCloudServerError(response.status_code, response.content)
+    if response.status_code != success_code:
+        print(response.content)
+        raise FireCloudServerError(response.status_code, response.content)
 
 def get_workflow_method_config(workspace_namespace, workspace_name, method_namespace, method_name, headers):
-  uri = f"https://api.firecloud.org/api/workspaces/{workspace_namespace}/{workspace_name}/method_configs/{method_namespace}/{method_name}"
-  return requests.get(uri, headers=headers)
+    uri = f"https://api.firecloud.org/api/workspaces/{workspace_namespace}/{workspace_name}/method_configs/{method_namespace}/{method_name}"
+    return requests.get(uri, headers=headers)
 
 def update_workflow_method_config(workspace_namespace, workspace_name, method_namespace, method_name, body, headers):
-  uri = f"https://api.firecloud.org/api/workspaces/{workspace_namespace}/{workspace_name}/method_configs/{method_namespace}/{method_name}"
-  return requests.post(uri, json=body, headers=headers)
+    uri = f"https://api.firecloud.org/api/workspaces/{workspace_namespace}/{workspace_name}/method_configs/{method_namespace}/{method_name}"
+    return requests.post(uri, json=body, headers=headers)
 
 def get_entities(workspace_namespace, workspace_name, etype, headers):
-  uri = f"https://api.firecloud.org/api/workspaces/{workspace_namespace}/{workspace_name}/entities/{etype}"
-  return requests.get(uri, headers=headers)
+    uri = f"https://api.firecloud.org/api/workspaces/{workspace_namespace}/{workspace_name}/entities/{etype}"
+    return requests.get(uri, headers=headers)
 
 def create_submission(workspace_namespace, workspace_name, method_namespace, method_name, headers,
                       entity=None, etype=None, expression=None, use_callcache=True):
-  uri = f"https://api.firecloud.org/api/workspaces/{workspace_namespace}/{workspace_name}/submissions"
-  body = {
-      "methodConfigurationNamespace": method_namespace,
-      "methodConfigurationName": method_name,
-      "useCallCache": use_callcache
-  }
-  if etype:
-    body["entityType"] = etype
-  if entity:
-    body["entityName"] = entity
-  if expression:
-    body["expression"] = expression
-  return requests.post(uri, json=body, headers=headers)
+    uri = f"https://api.firecloud.org/api/workspaces/{workspace_namespace}/{workspace_name}/submissions"
+    body = {
+        "methodConfigurationNamespace": method_namespace,
+        "methodConfigurationName": method_name,
+        "useCallCache": use_callcache
+    }
+    if etype:
+        body["entityType"] = etype
+    if entity:
+        body["entityName"] = entity
+    if expression:
+        body["expression"] = expression
+    return requests.post(uri, json=body, headers=headers)

--- a/scripts/launch_workflow_cf/utils.py
+++ b/scripts/launch_workflow_cf/utils.py
@@ -14,16 +14,24 @@ from oauth2client.service_account import ServiceAccountCredentials
 
 def prepare_and_launch(workspace_namespace, workspace_name, method_namespace, method_name,
                        secret_path, workflow_parameters, entity_set_name=None):
-  """Launch a Terra workflow.
+  """Launch a Terra workflow programmatically.
+
+    Arguments `workflow_parameters` and `entity_set_name` are used to specify the parameters to the
+    workflow. The Terra UI is used to control *all other aspects* of the workflow configuration, such as:
+    * which version of the method is to be used
+    * whether call caching is enabled
+    * whether to delete intermediate outputs
+    * the type of the root entity
+    * how the columns of the root entity map onto the workflow parameters
 
     Args:
       workspace_namespace: The project id of the Terra billing project in which the workspace resides.
-      workspace_name: The name of the workspace in which the workflow resides
+      workspace_name: The name of the workspace in which the workflow resides.
       method_namespace: The namespace of the workflow method.
       method_name: The name of the workflow method.
       secret_path: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
         testing locally, the filepath to the json key for the service account.
-      workflow_parameters: A dictionary of key value pairs to merge with the inputs from the workflow configuration,
+      workflow_parameters: A dictionary of key/value pairs to merge with the inputs from the workflow configuration,
         overwriting any duplicate keys.
       entity_set_name: The name of the entity set to be used for all other workflow parameters. Defaults to
         the most recently created entity set of the root entity type.
@@ -100,13 +108,13 @@ def prepare_and_launch(workspace_namespace, workspace_name, method_namespace, me
 def get_access_token(secret_path):
   """Conditionally create an access token with the minimum necessary scopes.
 
-  When run as a Cloud Function, a service account's json credentials file from Secret Manager
+  When run as a Cloud Function, a service account's JSON credentials file from Secret Manager
   is used to populate the access token. When run locally, either the service account JSON key file or the
   application default credential is used to populate the access token.
-  
+
   Args:
     secret_path: The 'Resource ID' of the service account key stored in Secret Manager. Or, if
-      testing locally, the filepath to the json key for the service account.
+      testing locally, the filepath to the JSON key for the service account.
   Returns:
     An access token.
   """


### PR DESCRIPTION
Also:
* added an example WDL and entity set to provide more context
* allow users to specify which entity set to use
* facilitate faster testing by authenticating locally as the service account
* refactor more of what was in main into utils
* rename parameters for clarity
* add pydocs
