### PR TITLE
make script to set requester pays on a Terra bucket - DFE-376

### DIFF
--- a/scripts/set_requester_pays.sh
+++ b/scripts/set_requester_pays.sh
@@ -3,7 +3,7 @@
 if (( $# < 1 )); then
   echo "Usage: $0 PROJECT_ID [PATH_TO_BUCKET_LIST_FILE]"
   echo "Unless you specify a source file, the script will read buckets from a file 'buckets.txt'."
-  echo "The source file must include newline-delimited gs://bucket-names"
+  echo "The source file must include newline-delimited bucket paths of format gs://fc-XXXXX"
   echo "NOTE: this script requires you to be authed as your firecloud.org admin account."
   exit 0
 elif (( $# == 1 )); then

--- a/scripts/set_requester_pays.sh
+++ b/scripts/set_requester_pays.sh
@@ -2,6 +2,7 @@
 
 if (( $# < 2 )); then
   echo "Usage: $0 PROJECT_ID gs://BUCKET1 [gs://BUCKET2 gs://BUCKET3...]"
+  echo "NOTE: this script requires you to be authed as your firecloud.org admin account."
   exit 0
 fi
 

--- a/scripts/set_requester_pays.sh
+++ b/scripts/set_requester_pays.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-if (( $# < 2 )); then
-  echo "Usage: $0 PROJECT_ID gs://BUCKET1 [gs://BUCKET2 gs://BUCKET3...]"
+if (( $# < 1 )); then
+  echo "Usage: $0 PROJECT_ID [PATH_TO_BUCKET_LIST_FILE]"
+  echo "Unless you specify a source file, the script will read buckets from a file 'buckets.txt'."
+  echo "The source file must include newline-delimited gs://bucket-names"
   echo "NOTE: this script requires you to be authed as your firecloud.org admin account."
   exit 0
+elif (( $# == 1 )); then
+  BUCKETS=$(cat buckets.txt)
+elif (( $# == 2 )); then
+  BUCKETS=$(cat $2)
 fi
 
 PROJECT_ID=$1
@@ -27,7 +33,7 @@ sleep 20
 # if needed for troubleshooting, this command retrieves the existing policy
 # gcloud beta projects get-iam-policy $PROJECT_ID
 
-for BUCKET in "${@:2}"; do
+for BUCKET in $BUCKETS; do
   # set requester pays
   gsutil requesterpays set on ${BUCKET} || exit 1
 done

--- a/scripts/set_requester_pays.sh
+++ b/scripts/set_requester_pays.sh
@@ -15,13 +15,14 @@ ROLE="projects/${PROJECT_ID}/roles/RequesterPays"
 echo "Enabling permissions for ${USER_EMAIL} to switch on Requester Pays"
 gcloud beta projects add-iam-policy-binding $PROJECT_ID --member=$MEMBER --role=$ROLE | grep -A 1 -B 1 "${MEMBER}"
 
-echo "Gatorcounting for 15 seconds while iam change goes into effect"
+echo ""
+echo "Gatorcounting for 20 seconds while iam change goes into effect"
 echo ""
 echo "NOTE: if you get an error message saying:"
 echo "    AccessDeniedException: 403 ${USER_EMAIL} does not have storage.buckets.update access to the Google Cloud Storage bucket."
-echo "THEN wait 10 seconds and run this again."
+echo "THEN gatorcount 10 more seconds and run this again."
 echo ""
-sleep 15
+sleep 20
 
 # if needed for troubleshooting, this command retrieves the existing policy
 # gcloud beta projects get-iam-policy $PROJECT_ID
@@ -32,5 +33,6 @@ for BUCKET in "${@:2}"; do
 done
 
 # revoke requesterpays permissions
+echo ""
 echo "Revoking permissions for ${USER_EMAIL} to edit Requester Pays"
 gcloud beta projects remove-iam-policy-binding $PROJECT_ID --member=$MEMBER --role=$ROLE | grep -A 1 -B 1 "${MEMBER}"

--- a/scripts/set_requester_pays.sh
+++ b/scripts/set_requester_pays.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if (( $# < 2 )); then
+  echo "Usage: $0 PROJECT_ID gs://BUCKET1 [gs://BUCKET2 gs://BUCKET3...]"
+  exit 0
+fi
+
+PROJECT_ID=$1
+
+MEMBER="user:marymorg@firecloud.org"
+ROLE="projects/${PROJECT_ID}/roles/RequesterPays"
+
+# enable requesterpays permissions
+echo "Enabling permissions to switch on Requester Pays"
+gcloud beta projects add-iam-policy-binding $PROJECT_ID --member=$MEMBER --role=$ROLE | grep -A 1 -B 1 "${MEMBER}"
+
+echo "Gatorcounting for 10 seconds while iam change goes into effect"
+sleep 10
+
+# gcloud beta projects get-iam-policy $PROJECT_ID
+
+for BUCKET in "${@:2}"; do
+  # set requester pays
+  gsutil requesterpays set on ${BUCKET} || exit 1
+done
+
+
+
+# revoke requesterpays permissions
+echo "Revoking permissions to edit Requester Pays"
+gcloud beta projects remove-iam-policy-binding $PROJECT_ID --member=$MEMBER --role=$ROLE | grep -A 1 -B 1 "${MEMBER}"


### PR DESCRIPTION
usage:
```
✗ ./set_requester_pays.sh
Usage: ./set_requester_pays.sh PROJECT_ID gs://BUCKET1 [gs://BUCKET2 gs://BUCKET3...]
NOTE: this script requires you to be authed as your firecloud.org admin account.
```

works like this:
```
✗ ./set_requester_pays.sh anvil-datastorage gs://fc-secure-d72b37f0-4431-48bf-b8f0-95b745deadbc
Your active configuration is: [new]
Enabling permissions for marymorg@firecloud.org to switch on Requester Pays
Updated IAM policy for project [anvil-datastorage].
- members:
  - user:marymorg@firecloud.org
  role: projects/anvil-datastorage/roles/RequesterPays

Gatorcounting for 20 seconds while iam change goes into effect

NOTE: if you get an error message saying:
    AccessDeniedException: 403 marymorg@firecloud.org does not have storage.buckets.update access to the Google Cloud Storage bucket.
THEN gatorcount 10 more seconds and run this again.

Enabling requester pays for gs://fc-secure-d72b37f0-4431-48bf-b8f0-95b745deadbc/...

Revoking permissions for marymorg@firecloud.org to edit Requester Pays
Updated IAM policy for project [anvil-datastorage].
```