### PR TITLE
update to Requester Pays script: use org-wide role that works for all projects

### DIFF
--- a/scripts/set_requester_pays.sh
+++ b/scripts/set_requester_pays.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if (( $# < 1 )); then
-  echo "Usage: $0 PROJECT_ID [PATH_TO_BUCKET_LIST_FILE]"
+  echo "Usage: $0 TERRA_PROJECT_ID [PATH_TO_TERRA_BUCKET_LIST_FILE]"
   echo "Unless you specify a source file, the script will read buckets from a file 'buckets.txt'."
-  echo "The source file must include newline-delimited bucket paths of format gs://fc-XXXXX"
+  echo "The source file must include newline-delimited Terra bucket paths of format gs://fc-XXXXX"
   echo "NOTE: this script requires you to be authed as your firecloud.org admin account."
   exit 0
 elif (( $# == 1 )); then
@@ -15,7 +15,10 @@ fi
 PROJECT_ID=$1
 USER_EMAIL=$(gcloud config get-value account)
 MEMBER="user:${USER_EMAIL}"
-ROLE="organizations/386193000800/roles/RequesterPaysToggler"
+
+# this is the firecloud.org id - should be used for all Terra projects
+ORG_ID="386193000800"
+ROLE="organizations/${ORG_ID}/roles/RequesterPaysToggler"
 
 # enable requesterpays permissions
 echo "Enabling permissions for ${USER_EMAIL} to switch on Requester Pays"

--- a/scripts/set_requester_pays.sh
+++ b/scripts/set_requester_pays.sh
@@ -15,23 +15,23 @@ fi
 PROJECT_ID=$1
 USER_EMAIL=$(gcloud config get-value account)
 MEMBER="user:${USER_EMAIL}"
-ROLE="projects/${PROJECT_ID}/roles/RequesterPays"
+ROLE="organizations/386193000800/roles/RequesterPaysToggler"
 
 # enable requesterpays permissions
 echo "Enabling permissions for ${USER_EMAIL} to switch on Requester Pays"
 gcloud beta projects add-iam-policy-binding $PROJECT_ID --member=$MEMBER --role=$ROLE | grep -A 1 -B 1 "${MEMBER}"
 
+# # if needed for troubleshooting, this command retrieves the existing policy
+# gcloud beta projects get-iam-policy $PROJECT_ID | grep -A 1 -B 1 "${MEMBER}"
+
 echo ""
-echo "Gatorcounting for 20 seconds while iam change goes into effect"
+echo "Gatorcounting for 10 seconds while iam change goes into effect"
 echo ""
 echo "NOTE: if you get an error message saying:"
 echo "    AccessDeniedException: 403 ${USER_EMAIL} does not have storage.buckets.update access to the Google Cloud Storage bucket."
 echo "THEN gatorcount 10 more seconds and run this again."
 echo ""
-sleep 20
-
-# if needed for troubleshooting, this command retrieves the existing policy
-# gcloud beta projects get-iam-policy $PROJECT_ID
+sleep 10
 
 for BUCKET in $BUCKETS; do
   # set requester pays


### PR DESCRIPTION
the change is to add an organization-wide role, "RequesterPaysToggler", that lives in the firecloud.org organization, that can be used with any project inside that org. the previous role used in this script wasn't available in all Terra projects and resulted in an error.

also decreased the wait time, since it'll involve manual re-running pretty much no matter what.