### PR TITLE
Changed input args to match those being passed.

### DIFF
--- a/scripts/van_allen_tools/set_up_vanallen_workspaces.py
+++ b/scripts/van_allen_tools/set_up_vanallen_workspaces.py
@@ -183,9 +183,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Set-up Van Allen Lab workspaces.')
 
     parser.add_argument('-t', '--tsv', required=True, type=str, help='tsv file with workspace name to create.')
-    parser.add_argument('-p', '--workspace_namespace', type=str, default=NAMESPACE, help='workspace project/namespace. default: vanallen-firecloud-nih')
+    parser.add_argument('-n', '--workspace_namespace', type=str, default=NAMESPACE, help='workspace project/namespace. default: vanallen-firecloud-nih')
 
     args = parser.parse_args()
 
     # call to create and set up workspaces
-    setup_workspaces(args.tsv, args.workspace_project)
+    setup_workspaces(args.tsv, args.workspace_namespace)


### PR DESCRIPTION
This pull request is for some minor changes to `scripts/van_allen_tools/set_up_vanallen_workspaces.py`, changing the input args to match those being passed to the `setup_workspaces` function. Specifically, the language was standardized to refer to namespaces instead of projects. 

It works great otherwise! I used the script to successfully create and share permissions for two new regional workspaces
```
(horsefish) (base) breardon@blueberry:van_allen_tools$ python set_up_vanallen_workspaces.py -t workspaces.txt -n vanallen-firecloud-nih
Successfully created workspace with name: SK_Ted_Rectal2_regional.
Successfully updated vanallen-firecloud-nih/SK_Ted_Rectal2_regional with the following user(s)/group(s): ['GROUP_vanallenlab@firecloud.org', 'breardon@broadinstitute.org', 'jpark@broadinstitute.org'].
Successfully created workspace with name: Melanoma.
Successfully updated vanallen-firecloud-nih/Melanoma with the following user(s)/group(s): ['GROUP_vanallenlab@firecloud.org', 'breardon@broadinstitute.org', 'jpark@broadinstitute.org'].
Number of workspaces passed set-up: 2/2
Number of workspaces failed set-up: 0/2
All workspace set-up (success or fail) details available in output file: 2021-03-31_13-04-56_workspaces_published_status.tsv
```