### PR TITLE
fix banner so it doesn't post twice

### DIFF
--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -96,13 +96,13 @@ if __name__ == '__main__':
     if args.link == '':
         args.link = DEFAULT_LINK
 
-    if args.delete:
-        clear_service_banner(args.env)
-
     # if user passes in a json file instead of individual string inputs
     if args.json:
         banner = convert_service_banner_json(args.json)
     else:
         banner = build_service_banner(args.title, args.message, args.link)
 
-    update_service_banner(args.env, banner)
+    if args.delete:
+        clear_service_banner(args.env)
+    else:
+        update_service_banner(args.env, banner)


### PR DESCRIPTION
In the old version:

```    
    if args.delete:
        clear_service_banner(args.env)

    # if user passes in a json file instead of individual string inputs
    if args.json:
        banner = convert_service_banner_json(args.json)
    else:
        banner = build_service_banner(args.title, args.message, args.link)

    update_service_banner(args.env, banner)
```

when the if/else about json args was added, the final call to `update_service_banner` was moved out of its if/else block.  so we were ALWAYS calling `update_service_banner`, whether we were putting it up or deleting it.  so in the case when delete was true, we called `clear_service_banner` (thus deleting the banner) and then just called `update_service_banner` again, thus putting it back up.

what we want to make sure happens is that the final call to update is an if/else: if delete is true, we call `clear_service_banner` only, otherwise we call `update_service_banner`. so that we only do one action: either delete or put up.