### PR TITLE
[DFE-479] delete objects from bucket based on paths listed in file

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -5,4 +5,8 @@ workflows:
    primaryDescriptorPath: /pipelines/migrate_bucket_regions/migrate_bucket_data_via_local.wdl
    testParameterFiles:
     - empty.json
-
+ - name: delete_bucket_data
+   subclass: WDL
+   primaryDescriptorPath: /pipelines/migrate_bucket_regions/delete_bucket_data.wdl
+   testParameterFiles:
+    - empty.json

--- a/pipelines/migrate_bucket_regions/delete_bucket_data.wdl
+++ b/pipelines/migrate_bucket_regions/delete_bucket_data.wdl
@@ -25,8 +25,12 @@ task delete_migrated_data_from_source {
 
     command {
 
+        # match final copy from local VM to destination log with original input file with files to migrate
+        # match with "destination" col in log (parse out extra folder structure we manually inject in migrate WDL)
+        # only delete objects where copy status is set to "OK"
+
         awk NR\>1  ~{copy_from_local_log} | tr "," "\t" | \  # remove header, set tab delimiter
-            awk -F"\t" '{$2 = substr($2, 46); print "gs://"$2, $9}' OFS="\t" | \  # get obj dest path, parse out extra folder
+            awk -F"\t" '{$2 = substr($2, 46); print "gs://"$2, $9}' OFS="\t" | \  # get obj dest path, parse out extra folder (46 chars from start)
             awk 'NR==FNR{a[$1]=$0;next}{$3=a[$2]}1' OFS="\t" - ~{source_bucket_details} | \  # match with input source details file
             awk -F"\t" '$4 == "OK"' | cut -f2 > objects_to_delete.txt  # only get rows where copy was successful ( = "OK")
 

--- a/pipelines/migrate_bucket_regions/delete_bucket_data.wdl
+++ b/pipelines/migrate_bucket_regions/delete_bucket_data.wdl
@@ -1,0 +1,46 @@
+version 1.0
+
+workflow delete_bucket_objects {
+    input {
+        File   source_bucket_details
+        File   copy_from_local_log
+    }
+
+    call delete_migrated_data_from_source {
+        input:
+            source_bucket_details = source_bucket_details,
+            copy_from_local_log = copy_from_local_log
+    }
+
+    output {
+        File objects_deleted = delete_migrated_data_from_source.deleted_files
+    }
+}
+
+task delete_migrated_data_from_source {
+    input {
+        File source_bucket_details
+        File copy_from_local_log
+    }
+
+    command {
+
+        awk NR\>1  ~{copy_from_local_log} | tr "," "\t" | \  # remove header, set tab delimiter
+            awk -F"\t" '{$2 = substr($2, 46); print "gs://"$2, $9}' OFS="\t" | \  # get obj dest path, parse out extra folder
+            awk 'NR==FNR{a[$1]=$0;next}{$3=a[$2]}1' OFS="\t" - ~{source_bucket_details} | \  # match with input source details file
+            awk -F"\t" '$4 == "OK"' | cut -f2 > objects_to_delete.txt  # only get rows where copy was successful ( = "OK")
+
+        cat objects_to_delete.txt | gsutil rm -
+    }
+
+    runtime {
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        memory: "2 GB"
+        disks: "local-disk 10 HDD"
+        zones: "us-central1-c us-central1-b"
+    }
+
+    output {
+        deleted_files = "objects_to_delete.txt"
+    }
+}

--- a/pipelines/migrate_bucket_regions/delete_bucket_data.wdl
+++ b/pipelines/migrate_bucket_regions/delete_bucket_data.wdl
@@ -24,12 +24,14 @@ task delete_migrated_data_from_source {
     }
 
     command {
+        set -x
+        set -e
 
         # match final copy from local VM to destination log with original input file with files to migrate
         # match with "destination" col in log (parse out extra folder structure we manually inject in migrate WDL)
         # only delete objects where copy status is set to "OK"
 
-        awk NR\>1  ~{copy_from_local_log} | tr "," "\t" | \  # remove header, set tab delimiter
+        awk NR\>1  ~{copy_from_local_log} | tr "," "\t" | \
             awk -F"\t" '{$2 = substr($2, 46); print "gs://"$2, $9}' OFS="\t" | \  # get obj dest path, parse out extra folder (46 chars from start)
             awk 'NR==FNR{a[$1]=$0;next}{$3=a[$2]}1' OFS="\t" - ~{source_bucket_details} | \  # match with input source details file
             awk -F"\t" '$4 == "OK"' | cut -f2 > objects_to_delete.txt  # only get rows where copy was successful ( = "OK")

--- a/pipelines/migrate_bucket_regions/migrate_bucket_data_via_local.wdl
+++ b/pipelines/migrate_bucket_regions/migrate_bucket_data_via_local.wdl
@@ -2,9 +2,7 @@ version 1.0
 
 workflow migrate_data_via_local {
     input {
-        String source_bucket_path
         String destination_bucket_path
-
         File   source_bucket_object_inventory
     }
 
@@ -21,38 +19,11 @@ workflow migrate_data_via_local {
     }
 
     output {
-        # File source_bucket_file_info = get_source_bucket_details.source_bucket_details_file
         Int calculated_memory_size = calculate_largest_file_size.max_gb
         File log_copy_from_src_to_local = copy_to_destination.copy_to_local_log
         File log_copy_from_local_to_dest = copy_to_destination.copy_from_local_log
     }
 }
-
-task get_source_bucket_details {
-    meta {
-        description: "Get a file with the list of file paths to copy and size of each file in bytes."
-    }
-
-    input {
-        String source_bucket_path
-    }
-
-    command {
-        gsutil du ~{source_bucket_path} | sed "/\/$/d" | tr " " "\t" | tr -s "\t" | sort -n -k1,1nr > source_bucket_details.txt
-    }
-
-    runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
-        memory: "2 GB"
-        disks: "local-disk 10 HDD"
-        zones: "us-central1-c us-central1-b"
-    }
-
-    output {
-        File source_bucket_details_file = "source_bucket_details.txt"
-    }
-}
-
 
 task calculate_largest_file_size {
     meta {
@@ -81,7 +52,6 @@ task calculate_largest_file_size {
         Int max_gb = read_int("file_gb")
     }
 }
-
 
 task copy_to_destination {
     meta {

--- a/pipelines/migrate_bucket_regions/migrate_bucket_data_via_local.wdl
+++ b/pipelines/migrate_bucket_regions/migrate_bucket_data_via_local.wdl
@@ -7,11 +7,6 @@ workflow migrate_data_via_local {
 
         File   source_bucket_object_inventory
     }
-    
-    # call get_source_bucket_details{
-    #     input:
-    #         source_bucket_path = source_bucket_path
-    # }
 
     call calculate_largest_file_size {
         input:


### PR DESCRIPTION
After van allen workspaces are migrated to their destination buckets via the `migrate_bucket_data_via_local.wdl`, use the same input source_objects.txt file as well as the `copy_from_local_log.csv` that is generated as output to cross reference successful copy of files to destination. If confirmed, delete objects from the source bucket.