### PR TITLE
edit readme and script to remove references to project parameter

### DIFF
--- a/scripts/anvil_tools/README.md
+++ b/scripts/anvil_tools/README.md
@@ -16,7 +16,7 @@
 ##### Description
     Update/add user/group to workspace ACL (as READER, WRITER, OWNER). 
     
-    Input is a .tsv file with 3 columns:
+    Input is a .tsv file with 4 columns:
         1. "workspace_name"
         2. "workspace_project"
         3. "email"

--- a/scripts/anvil_tools/README.md
+++ b/scripts/anvil_tools/README.md
@@ -18,18 +18,19 @@
     
     Input is a .tsv file with 3 columns:
         1. "workspace_name"
-        2. "email"
-        3. "accessLevel" - (READER, WRITER, or OWNER)
+        2. "workspace_project"
+        3. "email"
+        4. "accessLevel" - (READER, WRITER, or OWNER)
 ##### Usage
     Locally
-        `python3 /scripts/anvil_tools/add_user_to_workspace.py -t TSV_FILE [-p WORKSPACE_PROJECT]`
+        `python3 /scripts/anvil_tools/add_user_to_workspace.py -t TSV_FILE`
     Docker
-        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/add_user_to_workspace.py -t /data/INPUT.tsv [-p WORKSPACE_PROJECT]"`
+        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/add_user_to_workspace.py -t /data/INPUT.tsv"`
 
         Note: `local_data_directory` should be the path to the folder where your desired input .tsv file is located.
 ##### Flags
     1. `--tsv`, `-t`: input .tsv file (required)
-    2. `--project`, `-p`: workspace project/namespace for listed workspaces in tsv (default = anvil_datastorage)
+
 
 #### **file_exists_checker.sh**
 ##### Description

--- a/scripts/anvil_tools/add_user_to_workspace.py
+++ b/scripts/anvil_tools/add_user_to_workspace.py
@@ -1,7 +1,7 @@
 """Put/update user/group permissions to workspace - parsed from input tsv file.
 
 Usage:
-    > python3 add_user_to_workspace.py -t TSV_FILE [-p BILLING-PROJECT]"""
+    > python3 add_user_to_workspace.py -t TSV_FILE"""
 
 import argparse
 import pandas as pd


### PR DESCRIPTION
The script was updated to no longer accept a project - the project information is now parsed from a column in the input tsv. The script comments as well as readme were not updated to reflect the new format - fixed this now and tested with Candace.