### PR TITLE
[DFE-524] split large tsv file by workspace and project columns and push subset tsv to terra data model

### DIFF
--- a/scripts/anvil_tools/README.md
+++ b/scripts/anvil_tools/README.md
@@ -144,21 +144,24 @@
 ##### Description
     Specific collaborators or consortiums sometimes provide a single tsv file containing ONE entity type's (data table) data but for multiple workspaces - rather than the traditional single tsv per workspace. In the cases where a single tsv is provided, there are two additional columns that will be required of the user, workspace name and workspace project. These two extra columns denote which rows in the tsv need to be pushed to which workspace. This script will split the tsv into workspace specific tsv contents, create a json request, and push the table to the workspace.
 
-    Input is:
-        1. tsv file of a single entity_type's (data table) data - must contain columns with names -
+    Inputs are:
+        1. .tsv file - file of a single entity_type's (data table) data - must contain columns with names -
             a) "workspace_name"
             b) "workspace_project"
-        2. new line delimited txt file with attribute/column names ONLY IF there are array type columns/attributes -
+        2. .txt file - new line delimited .txt file with attribute/column names ONLY IF there are array type columns/attributes -
             a) ensure that the data in this column are at minimum comma separated to denote separate items in the array
+        3. `--json_output` flag if a local json file with the final json request is required (see below for use and default information)
     Output is:
-        NA - the console will show printouts with the success or failure of the request to push to each workspace
+        1. if (`--json_output` set) - `{workspace_project}_{workspace_name}_batch_upsert_request.json`
+        2. if (`--json_output` not set) - NA - console will show printouts with the success or failure of the request to push to each workspace
 ##### Usage
     Locally
-        `python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t TSV_FILE [-a ARRAY_COLUMNS_FILE]`
+        `python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t TSV_FILE [-a ARRAY_COLUMNS_FILE] [--json_output]`
     Docker
-        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t /data/INPUT.tsv [-a /data/ARRAY_COLUMNS_FILE]"`
+        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t /data/INPUT.tsv [-a /data/ARRAY_COLUMNS_FILE] [--json_output]"`
 
         Note: local_data_directory should be the path to the folder where your input .tsv file is located and where your output .tsv file will be placed.
 ##### Flags
     1. `--tsv`, `-t`: input .tsv file (required)
     2. `--array_columns`, `-a`: .txt file, new line delimited, to capture columns/attributes that are or array type (default = NO array type columns/attributes)
+    3. `--json_output`: parameter to set if a local json file of the final json request is required (default = NO local json output file created)

--- a/scripts/anvil_tools/README.md
+++ b/scripts/anvil_tools/README.md
@@ -93,7 +93,7 @@
         1. `{timestamp}_workspaces_setup_status.tsv`
 ##### Usage
     Locally
-        `python3 /scripts/anvil_tools/set_up_anvil_workspace.py -t TSV_FILE [-p WORKSPACE_PROJECT]
+        `python3 /scripts/anvil_tools/set_up_anvil_workspace.py -t TSV_FILE [-p WORKSPACE_PROJECT]`
     Docker
         `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/set_up_anvil_workspace.py -t /data/INPUT.tsv [-p WORKSPACE_PROJECT]"`
 
@@ -101,6 +101,30 @@
 ##### Flags
     1. `--tsv`, `-t`: input .tsv file (required)
     2. `--project`, `-p`: workspace project/namespace for listed workspaces in tsv (default = anvil_datastorage)
+
+
+#### **split_and_push_data_model_tsvs.py**
+##### Description
+    Specific collaborators or consortiums sometimes provide a single tsv file containing ONE entity type's (data table) data but for multiple workspaces - rather than the traditional single tsv per workspace. In the cases where a single tsv is provided, there are two additional columns that will be required of the user, workspace name and workspace project. These two extra columns denote which rows in the tsv need to be pushed to which workspace. This script will split the tsv into workspace specific tsv contents, create a json request, and push the table to the workspace.
+
+    Input is:
+        1. tsv file of a single entity_type's (data table) data - must contain columns with names -
+            a) "workspace_name"
+            b) "workspace_project"
+        2. new line delimited txt file with attribute/column names ONLY IF there are array type columns/attributes -
+            a) ensure that the data in this column is an array with "[]" around the contents
+    Output is:
+        NA - the console will show printouts with the success or failure of the request to push to each workspace
+##### Usage
+    Locally
+        `python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t TSV_FILE [-a ARRAY_COLUMNS_FILE]`
+    Docker
+        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t /data/INPUT.tsv [-a /data/ARRAY_COLUMNS_FILE]"`
+
+        Note: local_data_directory should be the path to the folder where your input .tsv file is located and where your output .tsv file will be placed.
+##### Flags
+    1. `--tsv`, `-t`: input .tsv file (required)
+    2. `--array_columns`, `-a`: .txt file, new line delimited, to capture columns/attributes that are or array type (default = NO array type columns/attributes)
 
 
 #### **post_workspace_attributes.py**

--- a/scripts/anvil_tools/README.md
+++ b/scripts/anvil_tools/README.md
@@ -82,51 +82,6 @@
     2. `--terra_project`, `-tp`: workspace project/namespace (default = "anvil-datastorage")
 
 
-#### **set_up_anvil_workspaces.py**
-##### Description
-    Create workspace with authorization domain and add user/groups with appropriate workspace ACLs. 
-    
-    Input is a .tsv file with columns:
-        1. "workspace_name"
-        2. "auth_domain_name"
-    Output is a .tsv file with name:
-        1. `{timestamp}_workspaces_setup_status.tsv`
-##### Usage
-    Locally
-        `python3 /scripts/anvil_tools/set_up_anvil_workspace.py -t TSV_FILE [-p WORKSPACE_PROJECT]`
-    Docker
-        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/set_up_anvil_workspace.py -t /data/INPUT.tsv [-p WORKSPACE_PROJECT]"`
-
-        Note: local_data_directory should be the path to the folder where your input .tsv file is located and where your output .tsv file will be placed.
-##### Flags
-    1. `--tsv`, `-t`: input .tsv file (required)
-    2. `--project`, `-p`: workspace project/namespace for listed workspaces in tsv (default = anvil_datastorage)
-
-
-#### **split_and_push_data_model_tsvs.py**
-##### Description
-    Specific collaborators or consortiums sometimes provide a single tsv file containing ONE entity type's (data table) data but for multiple workspaces - rather than the traditional single tsv per workspace. In the cases where a single tsv is provided, there are two additional columns that will be required of the user, workspace name and workspace project. These two extra columns denote which rows in the tsv need to be pushed to which workspace. This script will split the tsv into workspace specific tsv contents, create a json request, and push the table to the workspace.
-
-    Input is:
-        1. tsv file of a single entity_type's (data table) data - must contain columns with names -
-            a) "workspace_name"
-            b) "workspace_project"
-        2. new line delimited txt file with attribute/column names ONLY IF there are array type columns/attributes -
-            a) ensure that the data in this column is an array with "[]" around the contents
-    Output is:
-        NA - the console will show printouts with the success or failure of the request to push to each workspace
-##### Usage
-    Locally
-        `python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t TSV_FILE [-a ARRAY_COLUMNS_FILE]`
-    Docker
-        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t /data/INPUT.tsv [-a /data/ARRAY_COLUMNS_FILE]"`
-
-        Note: local_data_directory should be the path to the folder where your input .tsv file is located and where your output .tsv file will be placed.
-##### Flags
-    1. `--tsv`, `-t`: input .tsv file (required)
-    2. `--array_columns`, `-a`: .txt file, new line delimited, to capture columns/attributes that are or array type (default = NO array type columns/attributes)
-
-
 #### **post_workspace_attributes.py**
 ##### Description
     Post dataset attributes to workspaces.
@@ -162,3 +117,48 @@
 ##### Flags
     1. `--tsv`, `-t`: input .tsv file (required)
     2. `--project`, `-p`: workspace project/namespace for listed workspaces in tsv (default = anvil_datastorage)
+
+
+#### **set_up_anvil_workspaces.py**
+##### Description
+    Create workspace with authorization domain and add user/groups with appropriate workspace ACLs. 
+    
+    Input is a .tsv file with columns:
+        1. "workspace_name"
+        2. "auth_domain_name"
+    Output is a .tsv file with name:
+        1. `{timestamp}_workspaces_setup_status.tsv`
+##### Usage
+    Locally
+        `python3 /scripts/anvil_tools/set_up_anvil_workspace.py -t TSV_FILE [-p WORKSPACE_PROJECT]`
+    Docker
+        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/set_up_anvil_workspace.py -t /data/INPUT.tsv [-p WORKSPACE_PROJECT]"`
+
+        Note: local_data_directory should be the path to the folder where your input .tsv file is located and where your output .tsv file will be placed.
+##### Flags
+    1. `--tsv`, `-t`: input .tsv file (required)
+    2. `--project`, `-p`: workspace project/namespace for listed workspaces in tsv (default = anvil_datastorage)
+
+
+#### **split_and_push_data_model_tsvs.py**
+##### Description
+    Specific collaborators or consortiums sometimes provide a single tsv file containing ONE entity type's (data table) data but for multiple workspaces - rather than the traditional single tsv per workspace. In the cases where a single tsv is provided, there are two additional columns that will be required of the user, workspace name and workspace project. These two extra columns denote which rows in the tsv need to be pushed to which workspace. This script will split the tsv into workspace specific tsv contents, create a json request, and push the table to the workspace.
+
+    Input is:
+        1. tsv file of a single entity_type's (data table) data - must contain columns with names -
+            a) "workspace_name"
+            b) "workspace_project"
+        2. new line delimited txt file with attribute/column names ONLY IF there are array type columns/attributes -
+            a) ensure that the data in this column are at minimum comma separated to denote separate items in the array
+    Output is:
+        NA - the console will show printouts with the success or failure of the request to push to each workspace
+##### Usage
+    Locally
+        `python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t TSV_FILE [-a ARRAY_COLUMNS_FILE]`
+    Docker
+        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t /data/INPUT.tsv [-a /data/ARRAY_COLUMNS_FILE]"`
+
+        Note: local_data_directory should be the path to the folder where your input .tsv file is located and where your output .tsv file will be placed.
+##### Flags
+    1. `--tsv`, `-t`: input .tsv file (required)
+    2. `--array_columns`, `-a`: .txt file, new line delimited, to capture columns/attributes that are or array type (default = NO array type columns/attributes)

--- a/scripts/anvil_tools/README.md
+++ b/scripts/anvil_tools/README.md
@@ -152,8 +152,8 @@
             a) ensure that the data in this column are at minimum comma separated to denote separate items in the array
         3. `--json_output` flag if a local json file with the final json request is required (see below for use and default information)
     Output is:
-        1. if (`--json_output` set) - `{workspace_project}_{workspace_name}_batch_upsert_request.json`
-        2. if (`--json_output` not set) - NA - console will show printouts with the success or failure of the request to push to each workspace
+        1. if `--json_output` set - `{workspace_project}_{workspace_name}_batch_upsert_request.json`
+        2. if `--json_output` not set - NA - console will show printouts with the success or failure of the request to push to each workspace
 ##### Usage
     Locally
         `python3 /scripts/anvil_tools/split_and_push_data_model_tsvs.py -t TSV_FILE [-a ARRAY_COLUMNS_FILE] [--json_output]`

--- a/scripts/anvil_tools/batch_upsert_entities_standard.py
+++ b/scripts/anvil_tools/batch_upsert_entities_standard.py
@@ -56,27 +56,27 @@ def convert_string_to_list(input_string):
 
 
 def create_list_attr_operation(var_attribute_list_name):
-    """Return json request for a single operation to create an attribute of type array/list."""
+    """Return request string for a single operation to create an attribute of type array/list."""
 
     return '{"op":"CreateAttributeValueList","attributeName":"' + var_attribute_list_name + '"},'
 
 
 def add_list_member_operation(var_attribute_list_name, var_attribute_list_member):
-    """Return json request for a single operation to add a list member to an attribute of type array/list."""
+    """Return request string for a single operation to add a list member to an attribute of type array/list."""
 
     return '{"op":"AddListMember","attributeListName":"' + var_attribute_list_name + '", "newMember":"' + var_attribute_list_member + '"},'
 
 
 def create_non_array_attr_operation(var_attribute_name, var_attribute_value):
-    """Return json request for a single operation to create a non-array attribute."""
+    """Return request string for a single operation to create a non-array attribute."""
 
     return '{"op":"AddUpdateAttribute","attributeName":"' + var_attribute_name + '", "addUpdateAttribute":"' + var_attribute_value + '"},'
 
 
-def create_single_entity_request(var_entity_id, var_entity_type, single_entity_operations_list):
-    """Return json request with array/list attributes, their associated values/members, and single attribute operations."""
+def create_single_entity_request(var_entity_id, var_entity_type, single_entity_operations):
+    """Return request string with array/list attributes, their associated values/members, and single entity operations."""
 
-    return '{"name":"' + var_entity_id + '", "entityType":"' + var_entity_type + '", "operations":[' + single_entity_operations_list + ']}'
+    return '{"name":"' + var_entity_id + '", "entityType":"' + var_entity_type + '", "operations":[' + single_entity_operations + ']}'
 
 
 def create_upsert_request(tsv, array_attr_cols=None):

--- a/scripts/anvil_tools/batch_upsert_entities_standard.py
+++ b/scripts/anvil_tools/batch_upsert_entities_standard.py
@@ -55,6 +55,30 @@ def convert_string_to_list(input_string):
     return output_list
 
 
+def create_list_attr_operation(var_attribute_list_name):
+    """Return json request for a single operation to create an attribute of type array/list."""
+
+    return '{"op":"CreateAttributeValueList","attributeName":"' + var_attribute_list_name + '"},'
+
+
+def add_list_member_operation(var_attribute_list_name, var_attribute_list_member):
+    """Return json request for a single operation to add a list member to an attribute of type array/list."""
+
+    return '{"op":"AddListMember","attributeListName":"' + var_attribute_list_name + '", "newMember":"' + var_attribute_list_member + '"},'
+
+
+def create_non_array_attr_operation(var_attribute_name, var_attribute_value):
+    """Return json request for a single operation to create a non-array attribute."""
+
+    return '{"op":"AddUpdateAttribute","attributeName":"' + var_attribute_name + '", "addUpdateAttribute":"' + var_attribute_value + '"},'
+
+
+def create_single_entity_request(var_entity_id, var_entity_type, single_entity_operations_list):
+    """Return json request with array/list attributes, their associated values/members, and single attribute operations."""
+
+    return '{"name":"' + var_entity_id + '", "entityType":"' + var_entity_type + '", "operations":[' + single_entity_operations_list + ']}'
+
+
 def create_upsert_request(tsv, array_attr_cols=None):
     """Generate the request body for batchUpsert API."""
 
@@ -72,66 +96,58 @@ def create_upsert_request(tsv, array_attr_cols=None):
     # this is specific just to the first column where the format is required for terra load tsv files
     tsv.rename(columns={entity_type_col_name: entity_type}, inplace=True)
 
-    # templates
-    # for request body skeleton
-    template_req_body = """{"name":"VAR_ENTITY_ID", "entityType":"VAR_ENTITY_TYPE", "operations":[OPERATIONS_LIST]}"""
+    # initiate string to capture all operation requests for all rows (entities) in given tsv file
+    all_entities_request = []
 
-    # for operations - create/update: list attribute, add list member to attribute if list, single attribute and value
-    template_make_list_attr = '{"op":"CreateAttributeValueList","attributeName":"VAR_ATTRIBUTE_LIST_NAME"},'
-    template_add_list_member = '{"op":"AddListMember","attributeListName":"VAR_ATTRIBUTE_LIST_NAME", "newMember":"VAR_LIST_MEMBER"},'
-    template_make_single_attr = '{"op":"AddUpdateAttribute","attributeName":"VAR_ATTRIBUTE_NAME", "addUpdateAttribute":"VAR_ATTRIBUTE_MEMBER"},'
-
-    # initiate string to capture all operation requests
-    all_attributes_request = []
-
+    # for every row (entity) in df
     for index, row in tsv.iterrows():
-        single_attribute_request = ''''''
+        # initialize string to capture request for one row (entity) in tsv
+        single_entity_operations = ''''''
         # get the entity_id (row id - must be unique)
         entity_id = str(row[0])
 
-        # if array columns/attributes
+        # if array columns/attributes provided
         if array_attr_cols:
             # for each array column
             for col in array_attr_cols:
-                # add column name to template for a single attribute
-                single_attribute_request += template_make_list_attr.replace("VAR_ATTRIBUTE_LIST_NAME", col)
+                # get operation json to make the array/list attribute with column name
+                single_entity_operations += create_list_attr_operation(col)
                 # convert string value -> back into an array: [foo,bar] (str) --> ['foo', 'bar'] (list)
                 attr_values = convert_string_to_list(row[col])
-                # for each item in array, add row attribute value to the above created list attribute
+                # for each item in array (values pertaining to the list attribute as defined above)
                 for val in attr_values:
-                    single_attribute_request += template_add_list_member.replace("VAR_LIST_MEMBER", val).replace("VAR_ATTRIBUTE_LIST_NAME", col)
+                    # get operation json to add each array/list attribute's values to the request
+                    single_entity_operations += add_list_member_operation(col, val)
 
-            # get single attribute list based on which of the full tsv columns are array attributes
+            # get non-array/list attributes based on which of the full tsv columns are array attributes
             single_attr_cols = list(set(list(tsv.columns)) - set(array_attr_cols))
-        # if no array columns/attributes
+        # if no array columns/attributes provided
         else:
             single_attr_cols = list(tsv.columns)
 
-        # if there are single attribute columns - cases where all columns are arrays, single_attr_cols would be empty
+        # if there are non-array/list attribute columns - cases where all columns are arrays, single_attr_cols would be empty
         if single_attr_cols:
             # for each column that is not an array
             for col in single_attr_cols:
                 # get value in col from df
                 attr_value = str(row[col])
-                # add the request for attribute to list
-                single_attribute_request += template_make_single_attr.replace("VAR_ATTRIBUTE_MEMBER", attr_value).replace("VAR_ATTRIBUTE_NAME", col)
+                # get operation json with the row (entity) value to the non-array column (attribute)
+                single_entity_operations += create_non_array_attr_operation(col, attr_value)
 
         # remove trailing comma from the last request template
-        single_attribute_request = single_attribute_request[:-1]
+        single_entity_operations = single_entity_operations[:-1]
 
-        # put entity_type and entity_id in request body template
-        final_single_attribute_request = template_req_body.replace("VAR_ENTITY_ID", entity_id).replace("VAR_ENTITY_TYPE", entity_type)
-        # put operations list into request body template
-        final_single_attribute_request = final_single_attribute_request.replace("OPERATIONS_LIST", single_attribute_request)
+        # fill in entity_type (table name), entity_name (row id), and all entity operations into request body template
+        single_entity_request = create_single_entity_request(entity_id, entity_type, single_entity_operations)
 
-        # add the single workspace request to largest list of individual workspace requests
-        all_attributes_request.append(final_single_attribute_request)
+        # add the request pertinent to the rows (entities) of a single workspace to list of all workspace requests
+        all_entities_request.append(single_entity_request)
 
     # remove quotes around elements of the list but keep the brackets - using sep() or join() get rid of the brackets
-    # ['{}', '{}', '{}'] (api fails) --> [{}, {}, {}] (api succeeds)
-    all_attributes_request_formatted = '[%s]' % ','.join(all_attributes_request)
+    # ['{entity1}', '{entity2}', '{..}'] (api fails) --> [{entity1}, {entity2}, {..}] (api succeeds)
+    all_entities_request_formatted = '[%s]' % ','.join(all_entities_request)
 
-    return all_attributes_request_formatted
+    return all_entities_request_formatted
 
 
 if __name__ == '__main__':

--- a/scripts/anvil_tools/batch_usert_entities_standard.py
+++ b/scripts/anvil_tools/batch_usert_entities_standard.py
@@ -1,0 +1,136 @@
+import argparse
+import pandas as pd
+import requests
+
+from oauth2client.client import GoogleCredentials
+
+
+# function to get authorization bearer token for requests
+def get_access_token():
+    """Get access token."""
+
+    scopes = ["https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email"]
+    credentials = GoogleCredentials.get_application_default()
+    credentials = credentials.create_scoped(scopes)
+
+    return credentials.get_access_token().access_token
+
+
+def call_rawls_batch_upsert(workspace_name, project, request):
+    """Post entities to Terra workspace using batchUpsert."""
+
+    # rawls request URL for batchUpsert
+    uri = f"https://rawls.dsde-prod.broadinstitute.org/api/workspaces/{project}/{workspace_name}/entities/batchUpsert"
+
+    # Get access token and and add to headers for requests.
+    # -H  "accept: */*" -H  "Authorization: Bearer [token] -H "Content-Type: application/json"
+    headers = {"Authorization": "Bearer " + get_access_token(), "accept": "*/*", "Content-Type": "application/json"}
+
+    # capture response from API and parse out status code
+    response = requests.post(uri, headers=headers, data=request)
+    status_code = response.status_code
+
+    if status_code != 204:  # entities upsert fail
+        print(f"WARNING: Failed to upsert entities to {workspace_name}.")
+        print(response.text)
+        return
+
+    # entities upsert success
+    print(f"Successful upsert of entities to {workspace_name}.")
+
+
+def write_request_json(request):
+    """Create output file with json request."""
+
+    save_name = "batch_upsert_request.json"
+    with open(save_name, "w") as f:
+        f.write(request)
+
+
+def create_upsert_request(tsv, array_attr_cols=None):
+    """Generate the request body for batchUpsert API."""
+
+    # check if the tsv is formatted correctly - exit script if not in right load format
+    entity_type_col_name = tsv.columns[0]
+    entity_type = entity_type_col_name.rsplit("_", 1)[0].split(":")[1]
+    print(f"entity_type_col_name: {entity_type_col_name}")
+    print(f"entity_type: {entity_type}")
+    if not entity_type_col_name.startswith(("entity:", "membership:")):
+        print("Invalid tsv. The .tsv does not start with column entity:[table_name]_id or membership:[table_name]_id. Please correct and try again.")
+        return
+
+    # templates for request body components
+    template_req_body = '''{"name":"VAR_ENTITY_ID",
+                             "entityType":"VAR_ENTITY_TYPE",
+                             "operations":[OPERATIONS_LIST]}'''
+
+    template_make_list_attr = '{"op":"CreateAttributeValueList","attributeName":"VAR_ATTRIBUTE_LIST_NAME"},'
+    template_add_list_member = '{"op":"AddListMember","attributeListName":"VAR_ATTRIBUTE_LIST_NAME", "newMember":"VAR_LIST_MEMBER"},'
+    template_make_single_attr = '{"op":"AddUpdateAttribute","attributeName":"VAR_ATTRIBUTE_NAME", "addUpdateAttribute":"VAR_ATTRIBUTE_MEMBER"},'
+
+    # initiate string to capture all operation requests
+    single_attribute_request = ''''''
+    all_attributes_request = []
+
+    for index, row in tsv.iterrows():
+        # get the entity_id (row id - must be unique)
+        entity_id = str(row[0])
+        print(f"entity_id: {entity_id}")
+
+        # if there are array attribute columns
+        if array_attr_cols:
+            print(f"array_attr_cols: {array_attr_cols}")
+            # for each column that is an array
+            for col in array_attr_cols:
+                single_attribute_request += template_make_list_attr.replace("VAR_ATTRIBUTE_LIST_NAME", col)
+                # convert "array" from tsv which translates to a string back into an array
+                attr_values = str(row[col]).replace('"', '').strip('[]').split(",")
+                # print(f"attr_values: {attr_values}")
+                for val in attr_values:
+                    single_attribute_request += template_add_list_member.replace("VAR_LIST_MEMBER", val).replace("VAR_ATTRIBUTE_LIST_NAME", col)
+            # set the column values for the single attribute list based on which of the full tsv columns are array attributes
+            single_attr_cols = list(set(list(tsv.columns)) - set(array_attr_cols))
+        else:
+            single_attr_cols = list(tsv.columns)
+
+        print(f"single attribute reqest post arrays: {single_attribute_request}")
+
+        # if there are single attribute columns
+        if single_attr_cols:
+            print(f"single_attr_cols: {single_attr_cols}")
+            # for each column that is not an array
+            for col in single_attr_cols:
+                # get value in col from df
+                attr_value = str(row[col])
+                # print(f"attr_value: {attr_value}")
+
+                # add the request for attribute to list
+                single_attribute_request += template_make_single_attr.replace("VAR_ATTRIBUTE_MEMBER", attr_value).replace("VAR_ATTRIBUTE_NAME", col)
+
+        # remove trailing comma from the last request template
+        single_attribute_request = single_attribute_request[:-1]
+        # print(f"post singe attribute request: {single_attribute_request}")
+
+        # put entity_type and entity_id in request body template
+        final_single_attribute_request = template_req_body.replace("VAR_ENTITY_ID", entity_id).replace("VAR_ENTITY_TYPE", entity_type)
+        # put operations list into request body template
+        final_single_attribute_request = final_single_attribute_request.replace("OPERATIONS_LIST", single_attribute_request)
+
+        all_attributes_request.append(final_single_attribute_request)
+    # write out a json of the request body
+    # write_request_json(final_request)
+
+    return all_attributes_request
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('-w', '--workspace_name', required=True, help='name of workspace in which to make changes')
+    parser.add_argument('-p', '--project', required=True, help='billing project (namespace) of workspace in which to make changes')
+    parser.add_argument('-t', '--tsv', required=True, help='.tsv file formatted in load format to Terra UI')
+    args = parser.parse_args()
+
+    # create request body for batchUpsert
+    request = create_upsert_request(args.tsv)
+    # call batchUpsert API (rawls)
+    call_rawls_batch_upsert(args.workspace_name, args.project, request)

--- a/scripts/anvil_tools/convert_string_to_array_unit_test.py
+++ b/scripts/anvil_tools/convert_string_to_array_unit_test.py
@@ -1,0 +1,38 @@
+import batch_upsert_entities_standard
+
+# TEST: Converting a string into an array that is compatible with a tsv data model upload
+test_input_string = '"foo", "bar"'
+expected_output = ['foo', 'bar']
+assert batch_upsert_entities_standard.convert_string_to_list(test_input_string) == expected_output
+
+test_input_string = "'foo', 'bar'"
+expected_output = ['foo', 'bar']
+assert batch_upsert_entities_standard.convert_string_to_list(test_input_string) == expected_output
+
+test_input_string = ["foo", "bar"]
+expected_output = ['foo', 'bar']
+assert batch_upsert_entities_standard.convert_string_to_list(test_input_string) == expected_output
+
+test_input_string = ["foo",   "  bar"]
+expected_output = ['foo', 'bar']
+assert batch_upsert_entities_standard.convert_string_to_list(test_input_string) == expected_output
+
+test_input_string = ['foo', 'bar']
+expected_output = ['foo', 'bar']
+assert batch_upsert_entities_standard.convert_string_to_list(test_input_string) == expected_output
+
+test_input_string = "foo"
+expected_output = ["foo"]
+assert batch_upsert_entities_standard.convert_string_to_list(test_input_string) == expected_output
+
+test_input_string = 'foo'
+expected_output = ["foo"]
+assert batch_upsert_entities_standard.convert_string_to_list(test_input_string) == expected_output
+
+test_input_string = ["foo"]
+expected_output = ["foo"]
+assert batch_upsert_entities_standard.convert_string_to_list(test_input_string) == expected_output
+
+test_input_string = ['foo']
+expected_output = ["foo"]
+assert batch_upsert_entities_standard.convert_string_to_list(test_input_string) == expected_output

--- a/scripts/anvil_tools/split_and_push_data_model_tsvs.py
+++ b/scripts/anvil_tools/split_and_push_data_model_tsvs.py
@@ -8,7 +8,7 @@ import pandas as pd
 import batch_upsert_entities_standard
 
 
-def split_and_push_workspace_entities(tsv, array_column_names=None):
+def split_and_push_workspace_entities(tsv, array_column_names=None, json_output=None):
     """Create individual request body per unique project/workspace noted in tsv file and push request/data table to workspace."""
 
     # read full tsv into dataframe - contains all rows for all data across all workspaces
@@ -39,14 +39,18 @@ def split_and_push_workspace_entities(tsv, array_column_names=None):
         print(f"Creating json request.")
         json_request = batch_upsert_entities_standard.create_upsert_request(workspace_tsv, array_attr_cols)
 
-        # write out a json of the request body
-        print(f"Creating json request file locally.")
-        filename_prefix = f"{workspace_project}_{workspace_name}"
-        batch_upsert_entities_standard.write_request_json(json_request, filename_prefix)
+        # if local file containing final json request is requested, write json file
+        if json_output:
+            # write out a json of the request body
+            print(f"Creating json request file locally.")
+            filename_prefix = f"{workspace_project}_{workspace_name}"
+            batch_upsert_entities_standard.write_request_json(json_request, filename_prefix)
 
         # pass batchUpsert formatted request to FISS to make API call
         print(f"Uploading json request.")
         batch_upsert_entities_standard.call_rawls_batch_upsert(workspace_name, workspace_project, json_request)
+
+        
 
 
 if __name__ == "__main__":
@@ -55,12 +59,20 @@ if __name__ == "__main__":
 
     parser.add_argument('-t', '--tsv', required=True, type=str, help='tsv file in Terra data model load file format with workspace name and workspace project columns.')
     parser.add_argument('-a', '--array_columns', required=False, type=str, help='new line delimited file with array type column names/attributes in provided tsv.')
+    parser.add_argument('-j', '--json_output', required=False, action='store_true', help='set parameter if a local copy/file of the final json request is needed.')
 
     args = parser.parse_args()
+    # if a local copy of the final json request for API is needed
 
-    # with array type columns/attributes
-    if args.array_columns:
-        split_and_push_workspace_entities(args.tsv, args.array_columns)
-    # no array type columns/attributes
+    # if both array type columns/attributes
+    if args.json_output and args.array_columns:
+        split_and_push_workspace_entities(tsv=args.tsv, array_column_names=args.array_columns, json_output=args.json_output)
+    # if only array type columns/attributes
+    elif args.array_columns:
+        split_and_push_workspace_entities(tsv=args.tsv, array_column_names=args.array_columns)
+    # if only json request output file
+    elif args.json_output:
+        split_and_push_workspace_entities(tsv=args.tsv, json_output=args.json_output)
+    # if neither array type columns/attributes nor json request output file
     else:
-        split_and_push_workspace_entities(args.tsv)
+        split_and_push_workspace_entities(tsv=args.tsv)

--- a/scripts/anvil_tools/split_and_push_data_model_tsvs.py
+++ b/scripts/anvil_tools/split_and_push_data_model_tsvs.py
@@ -1,0 +1,60 @@
+"""Split single data model load tsv file by workspace_name (and workspace_project) into individual load tsv files and push to respective Terra workspace.
+
+Usage:
+    > python3 split_and_push_data_model_tsvs.py -t TSV_FILE"""
+
+import argparse
+import pandas as pd
+import batch_usert_entities_standard
+
+
+def create_single_workspace_tsv(tsv, array_column_names=None):
+    """Create individual request body per workspace and user/group listed in tsv file."""
+
+    # read full tsv into dataframe
+    tsv_all = pd.read_csv(tsv, sep="\t")
+
+    # start the array attribute column list as empty - fill in if user provides a file with list of column names of array type attributes
+    array_attr_cols = []
+    if array_column_names:
+        # read array column names into list
+        with open(array_column_names, "r") as f:
+            array_attr_cols = [i for line in f for i in line.split('\n')]
+
+    # get unique list of tuples where each tuple = (workspace_name, workspace_project)
+    # length of list = number of workspaces for which tsvs will be generated and pushed via FISS
+    all_workspaces = list(tsv_all[['workspace_name', 'workspace_project']].drop_duplicates().to_records(index=False))
+
+    # for each tuple in list (workspace, project)
+    for workspace in all_workspaces:
+        workspace_name = workspace[0]
+        workspace_project = workspace[1]
+
+        # get rows that match the combination of workspace_name and workspace_project, drop the workspace identifying columns
+        workspace_tsv = tsv_all.loc[(tsv_all['workspace_name'] == workspace_name) & (tsv_all['workspace_project'] == workspace_project)] \
+            .drop(['workspace_name', 'workspace_project'], axis=1)
+
+        print(f"Creating json request for {workspace_project}/{workspace_name}.")
+        json_request = batch_usert_entities_standard.create_upsert_request(workspace_tsv, array_attr_cols)
+        print(f'FINAL FULL REQUEST FOR THE ENTIRE TABLE: {json_request}')
+
+        exit(1)
+        print(f"Uploading json request for {workspace_project}/{workspace_name}.")
+        batch_usert_entities_standard.call_rawls_batch_upsert(workspace_name, workspace_project, json_request)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Set-up AnVIL external data delivery workspaces.')
+
+    parser.add_argument('-t', '--tsv', required=True, type=str, help='tsv file with workspace name and auth domains to create.')
+    parser.add_argument('-a', '--array_columns', required=False, type=str, help='new line delimited file with array type column names in provided tsv.')
+
+    args = parser.parse_args()
+
+    if args.array_columns:
+        print("There was a file provided with a list of columns that contain attributes of type array.")
+        create_single_workspace_tsv(args.tsv, args.array_columns)
+    else:
+        print("No file with columns of array type attributes was provided. This means all columns are attributes that are non-array.")
+        create_single_workspace_tsv(args.tsv)

--- a/scripts/anvil_tools/split_and_push_data_model_tsvs.py
+++ b/scripts/anvil_tools/split_and_push_data_model_tsvs.py
@@ -50,8 +50,6 @@ def split_and_push_workspace_entities(tsv, array_column_names=None, json_output=
         print(f"Uploading json request.")
         batch_upsert_entities_standard.call_rawls_batch_upsert(workspace_name, workspace_project, json_request)
 
-        
-
 
 if __name__ == "__main__":
 

--- a/scripts/anvil_tools/split_and_push_data_model_tsvs.py
+++ b/scripts/anvil_tools/split_and_push_data_model_tsvs.py
@@ -1,14 +1,14 @@
 """Split single data model load tsv file by workspace_name (and workspace_project) into individual load tsv files and push to respective Terra workspace.
 
 Usage:
-    > python3 split_and_push_data_model_tsvs.py -t TSV_FILE"""
+    > python3 split_and_push_data_model_tsvs.py -t TSV_FILE [-a ARRAY_COLUMNS_FILE]"""
 
 import argparse
 import pandas as pd
 import batch_usert_entities_standard
 
 
-def create_single_workspace_tsv(tsv, array_column_names=None):
+def split_and_push_workspace_entities(tsv, array_column_names=None):
     """Create individual request body per workspace and user/group listed in tsv file."""
 
     # read full tsv into dataframe
@@ -34,12 +34,10 @@ def create_single_workspace_tsv(tsv, array_column_names=None):
         workspace_tsv = tsv_all.loc[(tsv_all['workspace_name'] == workspace_name) & (tsv_all['workspace_project'] == workspace_project)] \
             .drop(['workspace_name', 'workspace_project'], axis=1)
 
-        print(f"Creating json request for {workspace_project}/{workspace_name}.")
+        print(f"Creating json request for {workspace_project}/{workspace_name}." + "\n")
         json_request = batch_usert_entities_standard.create_upsert_request(workspace_tsv, array_attr_cols)
-        print(f'FINAL FULL REQUEST FOR THE ENTIRE TABLE: {json_request}')
 
-        exit(1)
-        print(f"Uploading json request for {workspace_project}/{workspace_name}.")
+        print(f"Uploading json request for {workspace_project}/{workspace_name}." + "\n")
         batch_usert_entities_standard.call_rawls_batch_upsert(workspace_name, workspace_project, json_request)
 
 
@@ -53,8 +51,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.array_columns:
-        print("There was a file provided with a list of columns that contain attributes of type array.")
-        create_single_workspace_tsv(args.tsv, args.array_columns)
+        split_and_push_workspace_entities(args.tsv, args.array_columns)
     else:
-        print("No file with columns of array type attributes was provided. This means all columns are attributes that are non-array.")
-        create_single_workspace_tsv(args.tsv)
+        split_and_push_workspace_entities(args.tsv)
+

--- a/scripts/anvil_tools/split_and_push_data_model_tsvs.py
+++ b/scripts/anvil_tools/split_and_push_data_model_tsvs.py
@@ -9,7 +9,7 @@ import batch_usert_entities_standard
 
 
 def split_and_push_workspace_entities(tsv, array_column_names=None):
-    """Create individual request body per workspace and user/group listed in tsv file."""
+    """Create individual request body per workspace and user/group listed in tsv file and push rquest/data table to workspace."""
 
     # read full tsv into dataframe
     tsv_all = pd.read_csv(tsv, sep="\t")
@@ -19,7 +19,7 @@ def split_and_push_workspace_entities(tsv, array_column_names=None):
     if array_column_names:
         # read array column names into list
         with open(array_column_names, "r") as f:
-            array_attr_cols = [i for line in f for i in line.split('\n')]
+            array_attr_cols = [line.strip() for line in f]
 
     # get unique list of tuples where each tuple = (workspace_name, workspace_project)
     # length of list = number of workspaces for which tsvs will be generated and pushed via FISS
@@ -34,10 +34,11 @@ def split_and_push_workspace_entities(tsv, array_column_names=None):
         workspace_tsv = tsv_all.loc[(tsv_all['workspace_name'] == workspace_name) & (tsv_all['workspace_project'] == workspace_project)] \
             .drop(['workspace_name', 'workspace_project'], axis=1)
 
-        print(f"Creating json request for {workspace_project}/{workspace_name}." + "\n")
+        print(f"Starting entity updates to {workspace_project}/{workspace_name}:")
+        print(f"Creating json request.")
         json_request = batch_usert_entities_standard.create_upsert_request(workspace_tsv, array_attr_cols)
 
-        print(f"Uploading json request for {workspace_project}/{workspace_name}." + "\n")
+        print(f"Uploading json request.")
         batch_usert_entities_standard.call_rawls_batch_upsert(workspace_name, workspace_project, json_request)
 
 

--- a/scripts/anvil_tools/split_and_push_data_model_tsvs.py
+++ b/scripts/anvil_tools/split_and_push_data_model_tsvs.py
@@ -44,15 +44,16 @@ def split_and_push_workspace_entities(tsv, array_column_names=None):
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(description='Set-up AnVIL external data delivery workspaces.')
+    parser = argparse.ArgumentParser(description='Split single data model tsv and push individual tables using workspace/project column information.')
 
-    parser.add_argument('-t', '--tsv', required=True, type=str, help='tsv file with workspace name and auth domains to create.')
-    parser.add_argument('-a', '--array_columns', required=False, type=str, help='new line delimited file with array type column names in provided tsv.')
+    parser.add_argument('-t', '--tsv', required=True, type=str, help='tsv data model load file with workspace name and workspace project columns.')
+    parser.add_argument('-a', '--array_columns', required=False, type=str, help='new line delimited file with array type column names/attributes in provided tsv.')
 
     args = parser.parse_args()
 
+    # with array type columns/attributes
     if args.array_columns:
         split_and_push_workspace_entities(args.tsv, args.array_columns)
+    # no array type columns/attributes
     else:
         split_and_push_workspace_entities(args.tsv)
-

--- a/scripts/anvil_tools/split_and_push_data_model_tsvs.py
+++ b/scripts/anvil_tools/split_and_push_data_model_tsvs.py
@@ -5,7 +5,7 @@ Usage:
 
 import argparse
 import pandas as pd
-import batch_usert_entities_standard
+import batch_upsert_entities_standard
 
 
 def split_and_push_workspace_entities(tsv, array_column_names=None):
@@ -36,10 +36,10 @@ def split_and_push_workspace_entities(tsv, array_column_names=None):
 
         print(f"Starting entity updates to {workspace_project}/{workspace_name}:")
         print(f"Creating json request.")
-        json_request = batch_usert_entities_standard.create_upsert_request(workspace_tsv, array_attr_cols)
+        json_request = batch_upsert_entities_standard.create_upsert_request(workspace_tsv, array_attr_cols)
 
         print(f"Uploading json request.")
-        batch_usert_entities_standard.call_rawls_batch_upsert(workspace_name, workspace_project, json_request)
+        batch_upsert_entities_standard.call_rawls_batch_upsert(workspace_name, workspace_project, json_request)
 
 
 if __name__ == "__main__":

--- a/scripts/anvil_tools/split_and_push_data_model_tsvs.py
+++ b/scripts/anvil_tools/split_and_push_data_model_tsvs.py
@@ -9,15 +9,15 @@ import batch_upsert_entities_standard
 
 
 def split_and_push_workspace_entities(tsv, array_column_names=None):
-    """Create individual request body per workspace and user/group listed in tsv file and push rquest/data table to workspace."""
+    """Create individual request body per unique project/workspace noted in tsv file and push request/data table to workspace."""
 
-    # read full tsv into dataframe
+    # read full tsv into dataframe - contains all rows for all data across all workspaces
     tsv_all = pd.read_csv(tsv, sep="\t")
 
     # start the array attribute column list as empty - fill in if user provides a file with list of column names of array type attributes
     array_attr_cols = []
     if array_column_names:
-        # read array column names into list
+        # read array column names into list - strip out \n
         with open(array_column_names, "r") as f:
             array_attr_cols = [line.strip() for line in f]
 
@@ -30,14 +30,21 @@ def split_and_push_workspace_entities(tsv, array_column_names=None):
         workspace_name = workspace[0]
         workspace_project = workspace[1]
 
-        # get rows that match the combination of workspace_name and workspace_project, drop the workspace identifying columns
+        # get rows that match the combination of workspace_name and workspace_project, drop the workspace identifying columns (name + project)
         workspace_tsv = tsv_all.loc[(tsv_all['workspace_name'] == workspace_name) & (tsv_all['workspace_project'] == workspace_project)] \
             .drop(['workspace_name', 'workspace_project'], axis=1)
 
+        # pass in workspace subsetted tsv to convert the df into properly formatted batchUpsert request
         print(f"Starting entity updates to {workspace_project}/{workspace_name}:")
         print(f"Creating json request.")
         json_request = batch_upsert_entities_standard.create_upsert_request(workspace_tsv, array_attr_cols)
 
+        # write out a json of the request body
+        print(f"Creating json request file locally.")
+        filename_prefix = f"{workspace_project}_{workspace_name}"
+        batch_upsert_entities_standard.write_request_json(json_request, filename_prefix)
+
+        # pass batchUpsert formatted request to FISS to make API call
         print(f"Uploading json request.")
         batch_upsert_entities_standard.call_rawls_batch_upsert(workspace_name, workspace_project, json_request)
 
@@ -46,7 +53,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description='Split single data model tsv and push individual tables using workspace/project column information.')
 
-    parser.add_argument('-t', '--tsv', required=True, type=str, help='tsv data model load file with workspace name and workspace project columns.')
+    parser.add_argument('-t', '--tsv', required=True, type=str, help='tsv file in Terra data model load file format with workspace name and workspace project columns.')
     parser.add_argument('-a', '--array_columns', required=False, type=str, help='new line delimited file with array type column names/attributes in provided tsv.')
 
     args = parser.parse_args()


### PR DESCRIPTION
Description:
AnVIL collaborators will submit a single tsv file containing data they want uploaded as tables to workspaces. There will be two columns labeled as `workspace_name` and `workspace_project` PER row - multiple rows can have the same combination of workspace and project information. This just means that the entire set of rows will be uploaded to the same workspace.

The script parses on the unique combination of `workspace_name` and `workspace_project` --> subsets the large tsv file into smaller tsv files, representative of a single workspace's data table contents --> calls  functions from `batch_upsert_entities_standard.py` to create the json request PER subsetted tsv --> loads the table to its respective workspace.

Tests:
1. `convert_string_to_array_unit_test.py` will check that if array type columns/attributes were provided, that they are formatted in the correct way so that Terra will accept and represent them correctly as "# items" in the UI. The unit test imports the test function directly from `batch_upsert_entities_standard.py`.
2. Dockerhub tested from this feature branch to make sure that the README commands to run locally as well as from docker work as expected.

Notes:
1. The input tsv file will have the same formatted columns/attributes for ALL the workspaces. This means that this script can only create a single entity table. Every workspace will have a table named `entity_table_name` with its pertinent rows.
2. The script can handle columns/attributes that are intended to be arrays - for this the user has to provide an additional file input - it is optional and defaults to all columns/attributes being of NON-array type.
3. There is already a script named `batch_upsert_entities.py` that was created for covid-sabeti lab work but since the work around that is a bit up in the air, I did not want to modify the existing script. It is linked to some workflows that may or may not be in flight. Therefore, I made a new version, with the suffix `standard` to denote that this version can be used for every other case where you want to upload a .tsv to a workspace. Once sabeti lab work is confirmed to no longer depend on the specific version of the script that already exists, we can remove it.
