### PR TITLE
[DFE-594] get a single entity table from a list of workspaces and concatenate together into an excel report

### DIFF
--- a/scripts/anvil_tools/README.md
+++ b/scripts/anvil_tools/README.md
@@ -73,6 +73,32 @@
     2. `COLUMN_NUMBER_TO_CHECK`: number of column to parse from excel with gs;//XXXX paths (required)
 
 
+#### **gather_and_concatenate_data_model_tsvs.py**
+##### Description
+    This script will gather the given entity table metadata/data table from a list of given workspace names and projects. The final result is an excel file with the concatenated entity metadata in the format of a Terra load table with the addition of two columns - the workspace name and workspace project. This script is the inverse of split_and_push_data_model_tsvs.py.
+
+    Inputs are:
+        1. .xlsx file - two columns with names -
+            a) "workspace_name"
+            b) "workspace_project"
+        2. string - name of the entity table to gather from each workspace -
+            ex. "sample", "participant", "file"
+    Output is:
+        1. .xlsx file - `input_filename_final.xlsx` containing 2 sheets -
+            a) "concatenated_entity_table"
+            b) "failed_workspaces"
+##### Usage
+    Locally
+        `python3 /scripts/anvil_tools/gather_and_concatenate_data_model_tsvs.py -x EXCEL_FILE -e ENTITY_TABLE_NAME`
+    Docker
+        `docker run --rm -it -v "$HOME"/.config:/.config -v "$HOME"/local_data_directory/:/data broadinstitute/horsefish bash -c "cd data; python3 /scripts/anvil_tools/gather_and_concatenate_data_model_tsvs.py -x EXCEL_FILE -e ENTITY_TABLE_NAME"`
+
+        Note: local_data_directory should be the path to the folder where your input .xlsx file is located and where your output .xlsx file will be placed.
+##### Flags
+    1. `--excel`, `-x`: input .xlsx file (required)
+    2. `--entity`, `-e`: input entity table name to be pulled from each workspace in the input file
+
+
 #### **get_workspace_attributes.py**
 ##### Description 
     Gets the workspace's attributes from all the workspaces in a project and makes a master tsv containing Terra workspace attributes, where each row is a workspace and each column is a field in workspace attributes.

--- a/scripts/anvil_tools/gather_and_concatenate_data_model_tsvs.py
+++ b/scripts/anvil_tools/gather_and_concatenate_data_model_tsvs.py
@@ -66,7 +66,12 @@ def gather_and_concatenate_data_model_tsvs(input_file, entity_name):
     failed_data.to_excel(writer, sheet_name="failed_workspaces", index=None)
     writer.save()
 
-    print(f"Successfully completed gather and concatenate. All results can be found in {output_filename}.")
+    # if any failures, print warning message.
+    if len(failed_workspaces) > 0:
+        print(f"Warning: Completed gather and concatenate with the exception of some workspace/s. Please examine details in {output_filename}.")
+        return
+    # else print success message
+    print(f"Successfully completed gather and concatenate for all workspaces. Results can be found in {output_filename}.")
 
 
 if __name__ == "__main__":

--- a/scripts/anvil_tools/gather_and_concatenate_data_model_tsvs.py
+++ b/scripts/anvil_tools/gather_and_concatenate_data_model_tsvs.py
@@ -1,0 +1,81 @@
+"""Gather a single entity's data model metadata by workspace_name (and workspace_project) into a single load tsv file format and report in excel document.
+
+Usage:
+    > python3 gather_and_concatenate_data_model_tsvs.py -x EXCEL_FILE -e ENTITY_TABLE_NAME"""
+
+import argparse
+from firecloud import api as fapi
+from openpyxl import load_workbook
+import pandas as pd
+
+
+def gather_and_concatenate_data_model_tsvs(input_file, entity_name):
+    """Get data table tsv files from list of workspaces and concatenate results into a single excel report."""
+
+    # read full excel sheet into dataframe - all rows of workspace project and workspace names
+    workspace_info = pd.read_excel(input_file, sheet_name="Sheet1", index_col=None)
+
+    # instantiate empty list to hold all entity information from all workspaces
+    all_workspace_entities = []
+    failed_workspaces = []
+    # for each workspace_name, workspace_project pair
+    for index, workspace in workspace_info.iterrows():
+        # get workspace details
+        workspace_name = workspace["workspace_name"]
+        workspace_project = workspace["workspace_project"]
+
+        # get a response with all attributes for each row in entity table
+        entities = fapi.get_entities(workspace_project, workspace_name, entity_name)
+
+        # if get entities call fails, add workspace details to dictionary
+        # skip to next workspace
+        if entities.status_code != 200:
+            print(f"{entity_name} table in {workspace_project}/{workspace_name} does not exist or user does not have workspace access.")
+            failed_workspaces.append({"workspace_project": workspace_project, "workspace_name": workspace_name})
+            continue
+
+        # for each row in entity table, re-format nested response json
+        for entity in entities.json():
+            entity_attributes = entity["attributes"]  # [{attr name: attr value}] for each row
+            entity_id = entity["name"]         # name of entity
+
+            # insert entity_id, workspace_project, and workspace_name into list of dictionaries
+            entity_attributes[f"entity:{entity_name}_id"] = entity_id
+            entity_attributes["workspace_project"] = workspace_project
+            entity_attributes["workspace_name"] = workspace_name
+
+            # add entity informatioon (dictionary) to list
+            all_workspace_entities.append(entity_attributes)
+
+        print(f"{entity_name} table in {workspace_project}/{workspace_name} successfully gathered.")
+
+    # successful entity dictionaries -> df - dict per row (entity) for each entity table in all workspaces
+    succeeded_data = pd.DataFrame(all_workspace_entities)
+    # failed workspaces -> df
+    failed_data = pd.DataFrame(failed_workspaces)
+
+    # reorder dataframe entity:table_name column is first
+    ent_id_col = succeeded_data.pop(f"entity:{entity_name}_id")
+    succeeded_data.insert(0, ent_id_col.name, ent_id_col)
+
+    # # write final dataframes to excel file - separate sheets for success and failed data
+    output_filename = input_file.split("/")[-1].split(".")[0] + "_final.xlsx"
+    writer = pd.ExcelWriter(output_filename, engine="openpyxl")
+
+    succeeded_data.to_excel(writer, sheet_name="concatenated_entity_table", index=None)
+    failed_data.to_excel(writer, sheet_name="failed_workspaces", index=None)
+    writer.save()
+
+    print(f"Successfully completed gather and concatenate. All results can be found in {output_filename}.")
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Gather multiple data model tables using workspace/project column information and concatenate into single excel report.')
+
+    parser.add_argument('-x', '--excel', required=True, type=str, help='excel (.xlsx) file with workspace name and workspace project columns.')
+    parser.add_argument('-e', '--entity_name', required=True, type=str, help='name of data table to pull from each workspace.')
+
+    args = parser.parse_args()
+
+    gather_and_concatenate_data_model_tsvs(args.excel, args.entity_name)

--- a/scripts/anvil_tools/split_and_push_data_model_tsvs.py
+++ b/scripts/anvil_tools/split_and_push_data_model_tsvs.py
@@ -60,7 +60,6 @@ if __name__ == "__main__":
     parser.add_argument('-j', '--json_output', required=False, action='store_true', help='set parameter if a local copy/file of the final json request is needed.')
 
     args = parser.parse_args()
-    # if a local copy of the final json request for API is needed
 
     # if both array type columns/attributes
     if args.json_output and args.array_columns:


### PR DESCRIPTION
From a previous script - `split_and_push_data_model_tsvs.py` - a single file formatted as a Terra load table contains extra columns for workspace name and workspace project. Using this information, the single file is split and then uploaded as the appropriate table in its correct workspace.

This script does the opposite - gathers the given entity table from each of the workspaces listed and concatenates them into the format that is input into `split_and_push_data_models.py`.

A single excel file is input and a single excel file is output - the output excel file has two sheets where one is the list of workspaces that may have failed and the second is a single load tsv table format that represents the input of the script mentioned above.