### PR TITLE
[DFE-736] Fix ingest workflow outputs script to use "replace" functionality

### DIFF
--- a/scripts/tdr/twisttcap/export_pipeline_outputs_to_tdr.py
+++ b/scripts/tdr/twisttcap/export_pipeline_outputs_to_tdr.py
@@ -137,11 +137,9 @@ def get_existing_data(dataset_table_fq, primary_key_field, primary_key_value):
     result = executed_query.result()
 
     # this avoids the pyarrow error that arises if we use `df_result = result.to_dataframe()`
-    # df = results.to_dataframe_iterable()
-    # reader = next(df)
-    # df_result = pd.DataFrame(reader)
-    # try this again
-    df_result = result.to_dataframe()
+    df = results.to_dataframe_iterable()
+    reader = next(df)
+    df_result = pd.DataFrame(reader)
 
     # break if there's more than one row in TDR for this sample
     n_rows = len(df_result)

--- a/scripts/tdr/twisttcap/export_pipeline_outputs_to_tdr.py
+++ b/scripts/tdr/twisttcap/export_pipeline_outputs_to_tdr.py
@@ -105,9 +105,75 @@ def wait_for_job_status_and_result(job_id, wait_sec=10):
     return job_status, response.json()
 
 
-def main(dataset_id, bucket, target_table, outputs_json, sample_id):
-    # clean up bucket prefix
-    bucket = bucket.replace("gs://","")
+def clean_bucket_path(bucket_input):
+    """Removes gs:// prefix and trailing /"""
+    return bucket_input.replace("gs://", "").rstrip("/")
+
+
+def get_fq_bq_table(dataset_id, target_table):
+    uri = f"https://data.terra.bio/api/repository/v1/datasets/{dataset_id}?include=ACCESS_INFORMATION"
+    response = requests.get(uri, headers=get_headers())
+    tables = response.json()['accessInformation']['bigQuery']['tables']
+    dataset_table_fq = None  # fq = fully qualified name, i.e. project.dataset.table
+    for table_info in tables:
+        if table_info['name'] == target_table:
+            dataset_table_fq = table_info['qualifiedName']
+
+    if not dataset_table_fq:
+        # no table found
+        error_msg = f"No table named {target_table} was found in dataset {dataset_id}"
+        raise ValueError(error_msg)
+
+    return dataset_table_fq
+
+
+def get_existing_data(gcp_project, dataset_table_fq, primary_key_field, primary_key_value):
+    gcp_project = dataset_table_fq.split('.')[0]
+    bq = bigquery.Client(gcp_project)
+    query = f"SELECT * FROM `{dataset_table_fq}` WHERE {primary_key_field} = '{primary_key_value}'"
+    print("using query:" + query)
+
+    executed_query = bq.query(query)
+    result = executed_query.result()
+
+    # this avoids the pyarrow error that arises if we use `df_result = result.to_dataframe()`
+    # df = results.to_dataframe_iterable()
+    # reader = next(df)
+    # df_result = pd.DataFrame(reader)
+    # try this again
+    df_result = result.to_dataframe()
+
+    # break if there's more than one row in TDR for this sample
+    n_rows = len(df_result)
+    print(f"retrieved {n_rows} rows matching {primary_key_field} `{primary_key_value}`")
+    assert(n_rows == 1)
+
+    # format to a dictionary
+    print("formatting results to dictionary")
+    input_data_list = []
+    for row_id in df_result.index:
+        row_dict = {}
+        for col in df_result.columns:
+            if isinstance(df_result[col][row_id], pd._libs.tslibs.nattype.NaTType):
+                value = None
+            elif isinstance(df_result[col][row_id], pd._libs.tslibs.timestamps.Timestamp):
+                print(f'processing timestamp. value pre-formatting: {df_result[col][row_id]}')
+                formatted_timestamp = df_result[col][row_id].strftime('%Y-%m-%dT%H:%M:%S')
+                print(f'value post-formatting: {formatted_timestamp}')
+                value = formatted_timestamp
+            else:
+                value = df_result[col][row_id]
+            if value is not None:  # don't include empty values
+                row_dict[col] = value
+        input_data_list.append(row_dict)
+
+    # we have already asserted that there is only one row
+    return input_data_list[0]
+
+
+def main(dataset_id, bucket_input, target_table, outputs_json, pk_field, pk_value):
+    # clean up bucket string
+    bucket = clean_bucket_path(bucket_input)
 
     # read workflow outputs from file
     print(f"reading data from outputs_json file {outputs_json}")
@@ -116,16 +182,30 @@ def main(dataset_id, bucket, target_table, outputs_json, sample_id):
 
     # recode any paths (files) for TDR ingest
     print("recoding paths for TDR ingest")
-    outputs_to_load = recode_json_with_filepaths(outputs_dict)
+    outputs_to_add = recode_json_with_filepaths(outputs_dict)
+
+    # get BQ access info for TDR dataset
+    print("retrieving BQ access info for TDR dataset")
+    dataset_table_fq = get_fq_bq_table(dataset_id, target_table)
+
+    # retrieve data for this row
+    print(f"retrieving data for {pk_field} {pk_value} from {dataset_table_fq}")
+    row_data = get_existing_data(dataset_table_fq, pk_field, pk_value)
+
+    # update original row data with workflow outputs
+    row_data.update(outputs_to_add)
+    # remove and store datarepo_row_id
+    old_datarepo_row_id = row_data.pop('datarepo_row_id')
+    print(f"Replacing data from row with datarepo_row_id {old_datarepo_row_id}")
 
     # update version_timestamp field
     new_version_timestamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')
-    outputs_to_load['version_timestamp'] = new_version_timestamp
+    row_data['version_timestamp'] = new_version_timestamp
 
     # write update json to disk and upload to staging bucket
-    loading_json_filename = f"{sample_id}_{new_version_timestamp}_recoded_ingestDataset.json"
+    loading_json_filename = f"{pk_value}_{new_version_timestamp}_recoded_ingestDataset.json"
     with open(loading_json_filename, 'w') as outfile:
-        outfile.write(json.dumps(outputs_to_load))
+        outfile.write(json.dumps(row_data))
         outfile.write("\n")
     load_file_full_path = write_file_to_bucket(loading_json_filename, bucket)
 
@@ -134,7 +214,7 @@ def main(dataset_id, bucket, target_table, outputs_json, sample_id):
                         "path": load_file_full_path,
                         "table": target_table,
                         "resolve_existing_files": True,
-                        "updateStrategy": "update"
+                        "updateStrategy": "replace"
                         })
     uri = f"https://data.terra.bio/api/repository/v1/datasets/{dataset_id}/ingest"
     response = requests.post(uri, headers=get_headers('post'), data=load_json)
@@ -158,9 +238,16 @@ if __name__ == "__main__":
         help='name of destination table in the TDR dataset')
     parser.add_argument('-o', '--outputs_json', required=True,
         help='path to a json file defining the outputs to be loaded to TDR')
-    parser.add_argument('-s', '--sample_id', required=True,
-        help='the sample_id of the sample to be ingested')
+    parser.add_argument('-k', '--primary_key_field', required=True,
+        help='the name of the table\'s primary_key field')
+    parser.add_argument('-v', '--primary_key_value', required=True,
+        help='the primary key value for the row to update')
         
     args = parser.parse_args()
 
-    main(args.dataset_id, args.bucket, args.target_table, args.outputs_json, args.sample_id)
+    main(args.dataset_id,
+         args.bucket,
+         args.target_table,
+         args.outputs_json,
+         args.primary_key_field,
+         args.primary_key_value)

--- a/scripts/tdr/twisttcap/export_pipeline_outputs_to_tdr.py
+++ b/scripts/tdr/twisttcap/export_pipeline_outputs_to_tdr.py
@@ -127,7 +127,7 @@ def get_fq_bq_table(dataset_id, target_table):
     return dataset_table_fq
 
 
-def get_existing_data(gcp_project, dataset_table_fq, primary_key_field, primary_key_value):
+def get_existing_data(dataset_table_fq, primary_key_field, primary_key_value):
     gcp_project = dataset_table_fq.split('.')[0]
     bq = bigquery.Client(gcp_project)
     query = f"SELECT * FROM `{dataset_table_fq}` WHERE {primary_key_field} = '{primary_key_value}'"

--- a/scripts/tdr/twisttcap/export_pipeline_outputs_to_tdr.py
+++ b/scripts/tdr/twisttcap/export_pipeline_outputs_to_tdr.py
@@ -137,7 +137,7 @@ def get_existing_data(dataset_table_fq, primary_key_field, primary_key_value):
     result = executed_query.result()
 
     # this avoids the pyarrow error that arises if we use `df_result = result.to_dataframe()`
-    df = results.to_dataframe_iterable()
+    df = result.to_dataframe_iterable()
     reader = next(df)
     df_result = pd.DataFrame(reader)
 


### PR DESCRIPTION
I had misunderstood the new "updateStrategy": "replace" functionality in TDR ingest. Two major changes are implemented here:
- fix the flag from "update" (which doesn't exist, so it defaults to "append") to "replace"
- add back in the steps to pull existing data from TDR, since replace does not merge the new data with existing data