### PR TITLE
[SUP-633] Use tmp alerts.json file to create object and set caching metadata in one operation

### DIFF
--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -39,13 +39,13 @@ def update_service_banner(env, json_string=None):
         bucket = storage_client.get_bucket(f"firecloud-alerts-{env}")
         suitable_group = (f"fc-comms@{env}.test.firecloud.org")
 
-    # define required filename (alerts.json) and upload json string to gcs
-    blob = bucket.blob("alerts.json")
+    # define temporary filename (tmp/alerts.json) and upload json string to gcs
+    blob = bucket.blob("tmp/alerts.json")
     blob.upload_from_string(json_string)
 
     print("Setting permissions and security on banner json object in GCS location.")
-    # set metadata on json object (gsutil -m setmeta -r -h "Cache-Control:private, max-age=0, no-cache")
-    blob.cache_control = "max-age=0, no-cache"
+    # set metadata on json object (gsutil -m setmeta -r -h "Cache-Control:no-store")
+    blob.cache_control = "no-store"
     blob.patch()
 
     # set and save READ access for AllUsers on json object (gsutil ach ch -u AllUsers:R)
@@ -55,6 +55,13 @@ def update_service_banner(env, json_string=None):
     # set and save OWNER access for suitable_group on json object (gsutil ach ch -g suitable_group:O)
     blob.acl.group(suitable_group).grant_owner()
     blob.acl.save()
+
+    # copy the json out of the tmp location and to the real location. this is done to
+    # ensure that setting metadata on the object and creating the object happen at the same time
+    bucket.copy_blob(blob, bucket, "alerts.json")
+
+    # delete the temporary file
+    blob.delete()
 
     print("Banner action complete.")
 


### PR DESCRIPTION
This is another attempt to prevent clients from caching an outdated alerts.json file in Terra UI. With the current approach, there's a small window of time where a user may fetch the alerts object before the aggressive anti-caching metadata has been set on it. There is no way to upload an object and set it's metadata in one operation, so the approach here is to create the object in a temporary location, set the metadata on that, and then move the file to the real location (which preserves the metadata)

This is really hard to test, but per the comments on https://broadworkbench.atlassian.net/browse/SUP-633 this approach has a good track record. 