### PR TITLE
[SUP-633] Use temp file workaround to set cache metadata at object creation

### DIFF
--- a/scripts/terra_service_banner.py
+++ b/scripts/terra_service_banner.py
@@ -25,10 +25,6 @@ def build_service_banner(title, message, link):
     return json.dumps(banner_dict)
 
 
-# def set_iam_on_blob(blob):
-
-
-
 def update_service_banner(env, json_string=None):
     """Push json to bucket in selected environment."""
 


### PR DESCRIPTION
TAKE 2.

This is another attempt to prevent clients from caching an outdated alerts.json file in Terra UI. With the current approach, there's a small window of time where a user may fetch the alerts object before the aggressive anti-caching metadata has been set on it. There is no way to upload an object and set it's metadata in one operation, so the approach here is to create the object in a temporary location, set the metadata on that, and then move the file to the real location (which preserves the metadata)

This is really hard to test, but per the comments on https://broadworkbench.atlassian.net/browse/SUP-633 this approach has a good track record.