### PR TITLE
Updates to pipeline outputs to TDR, for Twist-TCAP

### DIFF
--- a/scripts/tdr/export_pipeline_outputs_to_tdr/changelog.md
+++ b/scripts/tdr/export_pipeline_outputs_to_tdr/changelog.md
@@ -3,6 +3,7 @@ Date of last commit: 2022-05-19
 
 * Add option to specify multiple custom fields for a "now" timestamp
 * Use array/records ingest mode to avoid needing a staging bucket
+* Improve error handling if ingest API call fails
 
 # 1.1
 

--- a/scripts/tdr/export_pipeline_outputs_to_tdr/changelog.md
+++ b/scripts/tdr/export_pipeline_outputs_to_tdr/changelog.md
@@ -1,0 +1,9 @@
+# 1.2
+Date of last commit: 2022-05-19
+
+* Add option to specify multiple custom fields for a "now" timestamp
+* Use array/records ingest mode to avoid needing a staging bucket
+
+# 1.1
+
+* Initial version

--- a/scripts/tdr/export_pipeline_outputs_to_tdr/changelog.md
+++ b/scripts/tdr/export_pipeline_outputs_to_tdr/changelog.md
@@ -1,10 +1,8 @@
 # 1.2
 Date of last commit: 2022-05-19
-
 * Add option to specify multiple custom fields for a "now" timestamp
 * Use array/records ingest mode to avoid needing a staging bucket
 * Improve error handling if ingest API call fails
 
 # 1.1
-
 * Initial version

--- a/scripts/tdr/export_pipeline_outputs_to_tdr/export_pipeline_outputs_to_tdr.py
+++ b/scripts/tdr/export_pipeline_outputs_to_tdr/export_pipeline_outputs_to_tdr.py
@@ -233,7 +233,7 @@ if __name__ == "__main__":
         help='the name of the table\'s primary_key field')
     parser.add_argument('-v', '--primary_key_value', required=True,
         help='the primary key value for the row to update')
-    parser.add_argument('-t', '--timestamp_field_list', action='append',
+    parser.add_argument('-f', '--timestamp_field_list', action='append',
         help='field that should be populated with timestamp at ingest time (can have more than one)')
 
     args = parser.parse_args()

--- a/scripts/tdr/export_pipeline_outputs_to_tdr/export_pipeline_outputs_to_tdr.py
+++ b/scripts/tdr/export_pipeline_outputs_to_tdr/export_pipeline_outputs_to_tdr.py
@@ -204,13 +204,18 @@ def main(dataset_id, target_table, outputs_json, pk_field, pk_value, timestamp_f
 
     # ingest data to TDR
     load_json = json.dumps({"format": "array",
-                        "records": row_data,
+                        "records": [row_data],
                         "table": target_table,
                         "resolve_existing_files": True,
                         "updateStrategy": "replace"
                         })
     uri = f"https://data.terra.bio/api/repository/v1/datasets/{dataset_id}/ingest"
     response = requests.post(uri, headers=get_headers('post'), data=load_json)
+    status_code = response.status_code
+    if status_code != 202:
+        error_msg = f"Error with ingest: {response.text}"
+        raise ValueError(error_msg)
+
     load_job_id = response.json()['id']
     job_status, job_info = wait_for_job_status_and_result(load_job_id)
     if job_status != "succeeded":

--- a/scripts/tdr/export_pipeline_outputs_to_tdr/export_pipeline_outputs_to_tdr.py
+++ b/scripts/tdr/export_pipeline_outputs_to_tdr/export_pipeline_outputs_to_tdr.py
@@ -171,7 +171,7 @@ def get_existing_data(dataset_table_fq, primary_key_field, primary_key_value):
     return input_data_list[0]
 
 
-def main(dataset_id, target_table, outputs_json, pk_field, pk_value):
+def main(dataset_id, target_table, outputs_json, pk_field, pk_value, timestamp_field_list):
 
     # read workflow outputs from file
     print(f"reading data from outputs_json file {outputs_json}")
@@ -197,8 +197,10 @@ def main(dataset_id, target_table, outputs_json, pk_field, pk_value):
     print(f"Replacing data from row with datarepo_row_id {old_datarepo_row_id}")
 
     # update version_timestamp field
-    new_version_timestamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')
-    row_data['version_timestamp'] = new_version_timestamp
+    if timestamp_field_list:
+        new_version_timestamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')
+        for field_name in timestamp_field_list:
+            row_data[field_name] = new_version_timestamp
 
     # ingest data to TDR
     load_json = json.dumps({"format": "array",
@@ -231,11 +233,14 @@ if __name__ == "__main__":
         help='the name of the table\'s primary_key field')
     parser.add_argument('-v', '--primary_key_value', required=True,
         help='the primary key value for the row to update')
-        
+    parser.add_argument('-t', '--timestamp_field_list', action='append',
+        help='field that should be populated with timestamp at ingest time (can have more than one)')
+
     args = parser.parse_args()
 
     main(args.dataset_id,
          args.target_table,
          args.outputs_json,
          args.primary_key_field,
-         args.primary_key_value)
+         args.primary_key_value,
+         args.timestamp_field_list)


### PR DESCRIPTION
meta updates:
- added a changelog to track versions
- update to version 1.2 of script/docker

functional updates:
- add option to specify multiple custom fields for a "now" timestamp
- use array/records ingest mode to avoid needing a staging bucket
- improve error handling if ingest API call fails

this has been tested with the Twist-TCAP pipeline, with corresponding WDL changes in this PR: https://github.com/broadinstitute/warp/pull/711