### PR TITLE
[DFE-770] Update ingest pipeline outputs to TDR

### DIFF
--- a/scripts/tdr/export_pipeline_outputs_to_tdr/changelog.md
+++ b/scripts/tdr/export_pipeline_outputs_to_tdr/changelog.md
@@ -1,3 +1,11 @@
+# 1.4
+Date of last commit: 2022-06-30
+* Add a single retry to ingest job
+
+# 1.3
+Date of last commit: 2022-06-29
+* Refactor to use merge strategy
+
 # 1.2
 Date of last commit: 2022-05-19
 * Add option to specify multiple custom fields for a "now" timestamp


### PR DESCRIPTION
This PR:
* changes ingest strategy over to `merge`, which allows us to cut out a bunch of code that we previously needed to fetch old data in TDR before making the update
* adds a retry of the ingest task, in case of transient failures on the TDR/Google side