### PR TITLE
[AT-412] Multi-bucket rsync script

### DIFF
--- a/scripts/anvil_tools/gsutil_bucket_sync.py
+++ b/scripts/anvil_tools/gsutil_bucket_sync.py
@@ -21,13 +21,8 @@ def parse_args():
     return parser.parse_args()
 
 
-def get_paths_df(input_file):
-    """Creates dataframe of source and destination path pairs."""
-    return pd.read_csv(input_file, sep="\t")
-
-
 def main(input_file):
-    paths_df = get_paths_df(input_file)
+    paths_df = pd.read_csv(input_file, sep="\t")
     for source_directory, destination_directory in paths_df.itertuples(
                 index=False, name="Paths"):
         subprocess.call(

--- a/scripts/anvil_tools/gsutil_bucket_sync.py
+++ b/scripts/anvil_tools/gsutil_bucket_sync.py
@@ -31,7 +31,6 @@ def main(input_file):
     for source_directory, destination_directory in paths_df.itertuples(
                 index=False, name="Paths"):
         subprocess.call(
-            # ["rsync", "-rv", source_directory, destination_directory])
             ["gsutil", "-m", "rsync", "-r",
                 source_directory, destination_directory]
         )

--- a/scripts/anvil_tools/gsutil_bucket_sync.py
+++ b/scripts/anvil_tools/gsutil_bucket_sync.py
@@ -1,0 +1,41 @@
+import subprocess
+import argparse
+import pandas as pd
+"""
+Script to sync between a source google bucket (aka staging) and
+a destination google bucket (aka production). 
+Takes in a tab-delimited file with a header and two columns:
+Destination directory and Source directory.
+
+It runs gsutil rsync for each pair of folders, copying all
+changed files from destination to source.
+"""
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_file',
+                        help="Path to tsv file containing list of \
+                        source/destination folders to sync between")
+    return parser.parse_args()
+
+
+def get_paths_df(input_file):
+    """Creates dataframe of source and destination path pairs."""
+    return pd.read_csv(input_file, sep="\t")
+
+
+def main(input_file):
+    paths_df = get_paths_df(input_file)
+    for source_directory, destination_directory in paths_df.itertuples(
+                index=False, name="Paths"):
+        subprocess.call(
+            # ["rsync", "-rv", source_directory, destination_directory])
+            ["gsutil", "-m", "rsync", "-r",
+                source_directory, destination_directory]
+        )
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args.input_file)

--- a/scripts/anvil_tools/gsutil_bucket_sync.py
+++ b/scripts/anvil_tools/gsutil_bucket_sync.py
@@ -16,7 +16,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('input_file',
                         help="Path to tsv file containing list of \
-                        source/destination folders to sync between")
+                        source (column 1) and destination (column 2)\
+                        gsURIs to sync between")
     return parser.parse_args()
 
 


### PR DESCRIPTION
Script to sync between a source google bucket (aka staging) and a destination google bucket (aka production). 

Takes in a tab-delimited file with a header and two columns: 'Destination directory' and 'Source directory'.

It runs gsutil rsync for each pair of folders, copying all changed files from destination to source.


I'll be writing up a FE ticket to create a ops portal workflow that does this (so PjMs can take over this part of the ingest workflow completely), but this is a prototype/can be used ad hoc in the meantime. 