### PR TITLE
RARE-X: ignore ingest json files with 0 data to ingest into dataset

### DIFF
--- a/scripts/rare-x/ingest_rarex_dataset.py
+++ b/scripts/rare-x/ingest_rarex_dataset.py
@@ -154,10 +154,10 @@ def get_ingest_data_json_filepaths(bucket_name, subdir):
 
     blobs = storage_client.list_blobs(bucket_name, prefix=prefix, delimiter=delimiter)
 
-    # capture paths to json files containing data to ingest at listed bucket path
+    # capture paths to json files containing data to ingest at listed bucket path if they are not empty
     paths = []
     for blob in blobs:
-        if blob.name.endswith(".json"):
+        if blob.name.endswith(".json") and blob.size > 0:
             paths.append(f"gs://{bucket_name}/{blob.name}")
 
     if not paths:


### PR DESCRIPTION
RARE-X receives json files for ingest from external source. 
If there is no data to be ingested, an empty json file is deposited in the bucket which breaks the ingest script.
Check for the size of the json to ensure that it is not empty before adding it to list of files to loop through to ingest into dataset.
