### PR TITLE
Adding get_batch_job_status

### DIFF
--- a/scripts/dragen_reprocessing/get_batch_job_status.py
+++ b/scripts/dragen_reprocessing/get_batch_job_status.py
@@ -56,7 +56,7 @@ join `{self.google_project}.dragen_illumina.tasks_status` as s on a.job_id = s.j
                 sample_dict['job_ids'].add(row['job_id'])
                 # If entry has latest timestamp use this status
                 if row['timestamp'] > sample_dict['latest_timestamp']:
-                    sample_dict['timestamp'] = row['timestamp']
+                    sample_dict['latest_timestamp'] = row['timestamp']
                     sample_dict['latest_status'] = row['status']
         return samples_dict
 

--- a/scripts/dragen_reprocessing/get_batch_job_status.py
+++ b/scripts/dragen_reprocessing/get_batch_job_status.py
@@ -1,0 +1,81 @@
+from argparse import ArgumentParser, Namespace
+import google.auth
+import logging
+from typing import Any
+from google.cloud import bigquery
+from pathlib import Path
+
+
+logging.basicConfig(
+    format="%(levelname)s: %(asctime)s : %(message)s", level=logging.INFO
+)
+
+
+class GetSampleInfo:
+    def __init__(self, google_project: str):
+        credentials, your_project_id = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+        self.google_project = google_project
+        self.bqclient = bigquery.Client(credentials=credentials, project=google_project)
+
+    def query_for_batch_job_info(self) -> Any:
+        """Gets all batch job info from bigquery"""
+        query_string = f"""SELECT a.job_id, a.input_path, s.status, s.timestamp
+FROM `{self.google_project}.dragen_illumina.job_array` as a
+join `{self.google_project}.dragen_illumina.tasks_status` as s on a.job_id = s.job_id"""
+
+        logging.info(f"Querying for jobs status")
+
+        # API request - start query, pass in extra configuration
+        query_job = self.bqclient.query(query_string)
+
+        # wait for the job to complete
+        return query_job.result()
+
+    def create_sample_dict(self, row: dict, sample_name: str) -> dict:
+        """Create an initial sample dict"""
+        return {
+            'sample_name': sample_name,
+            'latest_status': row['status'],
+            'latest_timestamp': row['timestamp'],
+            # Start a set for job ids
+            'job_ids': {row['job_id']}
+        }
+
+    def create_full_samples_dicts(self, query_results: Any) -> dict:
+        """Creates full dictionary where key is sample name and value is dict with all jobs info"""
+        samples_dict = {}
+        for row in query_results:
+            # Get sample name from cram input
+            sample_name = Path(row['input_path']).stem
+            if sample_name not in samples_dict:
+                # Create initial dict
+                samples_dict[sample_name] = self.create_sample_dict(row, sample_name)
+            else:
+                sample_dict = samples_dict[sample_name]
+                # Add to job ids set
+                sample_dict['job_ids'].add(row['job_id'])
+                # If entry has latest timestamp use this status
+                if row['timestamp'] > sample_dict['latest_timestamp']:
+                    sample_dict['timestamp'] = row['timestamp']
+                    sample_dict['latest_status'] = row['status']
+        return samples_dict
+
+    def run(self) -> dict:
+        query_results = self.query_for_batch_job_info()
+        return self.create_full_samples_dicts(query_results)
+
+
+def get_args() -> Namespace:
+    parser = ArgumentParser(description='Query BQ table with GCS bucket object metadata inventory.')
+
+    parser.add_argument('-g', '--gcp_project', type=str, help='Google project used for BigQuery.',
+                        choices=['gp-cloud-dragen-dev', 'gp-cloud-dragen-prod'], required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = get_args()
+    gcp_project = args.gcp_project
+
+    samples_dict = GetSampleInfo(google_project=gcp_project).run()
+    # TODO: Once we figure out what tables will look like the next step is create new samples tsv and uploading to workspace

--- a/scripts/dragen_reprocessing/get_batch_job_status.py
+++ b/scripts/dragen_reprocessing/get_batch_job_status.py
@@ -22,8 +22,8 @@ class GetSampleInfo:
     def _query_for_batch_job_info(self) -> Any:
         """Gets all batch job info from bigquery"""
         query_string = f"""SELECT a.job_id, a.input_path, s.status, s.timestamp, a.output_path
-FROM `gp-cloud-dragen-dev.dragen_illumina.job_array` as a
-join `gp-cloud-dragen-dev.dragen_illumina.tasks_status` as s on a.job_id = s.job_id
+FROM `{self.google_project}.dragen_illumina.job_array` as a
+join `{self.google_project}.dragen_illumina.tasks_status` as s on a.job_id = s.job_id
   and CAST(a.batch_task_index AS STRING)=REGEXP_EXTRACT(task_id, r'group0-(\d+)')
 where DATETIME "{self.maximum_run_date}" > a.timestamp
 and DATETIME "{self.minimum_run_date}" < a.timestamp"""


### PR DESCRIPTION
Gets information like below for each sample: 
```
$ python3 scripts/dragen_reprocessing/get_batch_job_status.py -g gp-cloud-dragen-dev -t test.tsv
INFO: 2024-03-07 14:02:23,337 : Querying for jobs status
INFO: 2024-03-07 14:02:24,920 : Creating test.tsv
To upload tsv to workspace run:
python3 scripts/import_large_tsv/import_large_tsv.py --project <workspace-project> --workspace <workspace_name> --tsv test.tsv
```
tsv inputs looks like
```
entity:sample_id	attempts	latest_status	output_path	last_attempt
fake_project_NA0_v1_WGS_GCP	3	SUCCEEDED	gs://gp-cloud-dragen-dev-output/3_78/aggregation/NA0/2024-02-05-22-33-31	2024-02-06 01:11:02
fake_project_NA12878_v1_WGS_GCP	8	FAILED	gs://fc-236ab095-52ca-4541-bcaa-795635feccd9/repro_output/NA12878/2024-02-01-21-50-25	2024-03-07 15:42:46
fake_project_PC83938064_v1_WGS_GCP	13	FAILED	gs://gp-cloud-dragen-dev-output/3_78/aggregation/PC83938064/2024-02-13-03-20-13	2024-03-07 15:42:46
fake_project_ROS_001_18Y00520_D1_v1_WGS_GCP	1	SUCCEEDED	gs://gp-cloud-dragen-dev-output/3_78/aggregation/ROS_001_18Y00520_D1/2024-02-01-21-20-14	2024-02-01 22:19:43
fake_project_SC10834401_v1_WGS_GCP	8	FAILED	gs://gp-cloud-dragen-dev-output/3_78/aggregation/SC10834401/2024-02-07-21-24-48	2024-02-12 21:51:33
```