### PR TITLE
FE-235 adding pseudo code doc for copying from TDR to GCS (HCA)

### DIFF
--- a/scripts/tdr/copy_from_tdr_to_gcs/README.md
+++ b/scripts/tdr/copy_from_tdr_to_gcs/README.md
@@ -1,0 +1,17 @@
+# Copy from TDR to GCS
+This was originally a bash script written by Samantha Velasquez\
+[get_snapshot_files_and_transfer.sh](get_snapshot_files_and_transfer.sh) \
+which was written to copy files from a TDR snapshot to an Azure bucket.\
+Bobbie then translated to python using CoPilot.\
+[copy_from_tdr_to_gcs.py](copy_from_tdr_to_gcs.py) \
+**This script is not yet tested.**
+
+
+## TODO
+- [ ] fix requirements.txt as needed
+- [ ] update the script to copy to staging /data bucket
+- [ ] update the script to take in a csv containing the institution & project UUID for HCA
+- [ ] optional - update the script with conditional logic to accept a snapshot ID and destination instead
+- [ ] take care of any remaining TODOs in the script
+- [ ] test/debug/update script
+- [ ] add Dockerfile > push Docker image to artifact registry (check with Field Eng as to where to push)

--- a/scripts/tdr/copy_from_tdr_to_gcs/from_bash_copy_from_tdr.py
+++ b/scripts/tdr/copy_from_tdr_to_gcs/from_bash_copy_from_tdr.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import json
+import requests
+import subprocess
+from google.auth import compute_engine
+from google.auth.transport.requests import Request
+
+# input should be a manifest csv of those projects that need data copied back
+# Check if a filename is provided as an argument
+if len(sys.argv) != 2:
+    print("Usage: python3 script.py <filename>")
+    sys.exit(1)
+
+filename = sys.argv[1]
+
+# Check if the file exists
+if not os.path.isfile(filename):
+    print(f"File {filename} not found")
+    sys.exit(1)
+
+# Read the file line by line
+with open(filename, 'r') as file:
+    lines = file.read().splitlines()
+
+# TODO create the list of snapshot IDs from the list of UUIDs
+# use manifest.csv to get the UUIDs that need data copied back
+# for each UUID, construct the snapshot name - which will be latest snapshot with a dataset id like
+# "hca_prod_<uuid-without-dashes>*"
+# use those dataset ids to get the latest snapshot id for each dataset
+# this then becomes the lines list
+
+# TODO - is this needed? or can we just run locally as Monster members?
+# Get access token
+credentials = compute_engine.Credentials()
+credentials.refresh(Request())
+access_token = credentials.token
+
+for snapshot in lines:
+    # Make request to the API with the current snapshot
+    response = requests.get(f"https://data.terra.bio/api/repository/v1/snapshots/{snapshot}/files?offset=0&limit=10000",
+                            headers={'accept': 'application/json', 'Authorization': f'Bearer {access_token}'})
+
+    # Write the response to a JSON file
+    with open(f"response_{snapshot}.json", 'w') as outfile:
+        json.dump(response.json(), outfile)
+
+    # Extract file details from the JSON file and append them to a text file
+    with open(f"response_{snapshot}.json", 'r') as json_file:
+        data = json.load(json_file)
+        with open("list_of_access_urls.txt", 'a') as outfile:
+            for item in data:
+                outfile.write(item['fileDetail']['accessUrl'] + '\n')
+
+
+# Read the list of files from list_of_filepaths.txt and copy them using gcloud storage cp
+with open("list_of_access_urls.txt", 'r') as file:
+    access_urls = file.read().splitlines()
+
+# TODO
+# copy command will look something like\
+# gcloud storage cp gs://datarepo-4bcb4408-bucket/2e2aac27-3bf5-4a89-b466-e563cf99aef2/07a78be1-c75f-4463-a1a4-d4f7f9771ca5/SRR3562314_2.fastq.gz gs://broad-dsp-monster-hca-prod-ebi-storage/broad_test_dataset/07e5ebc0-1386-4a33-8ce4-3007705adad8/data/.
+# Also need to construct the staging/data gs:// path from the manifest.csv
+# "EBI": "gs://broad-dsp-monster-hca-prod-ebi-storage/prod",
+# "UCSC": "gs://broad-dsp-monster-hca-prod-ebi-storage/prod",
+# "LANTERN": "gs://broad-dsp-monster-hca-prod-lantern",
+#  "LATTICE": "gs://broad-dsp-monster-hca-prod-lattice/staging",
+for access_url in access_urls:
+    subprocess.run(['gcloud storage', 'cp', access_url, "<INSERT STAGING /DATA url>"])

--- a/scripts/tdr/copy_from_tdr_to_gcs/get_snapshot_files_and_transfer.sh
+++ b/scripts/tdr/copy_from_tdr_to_gcs/get_snapshot_files_and_transfer.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+
+# Check if a filename is provided as an argument
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <filename>"
+    exit 1
+fi
+
+# Check if the file exists
+if [ ! -f "$1" ]; then
+    echo "File $1 not found"
+    exit 1
+fi
+
+# Add a newline character at the end of the file
+echo >> "$1"
+
+# Read the file line by line
+while IFS= read -r snapshot || [ -n "$snapshot" ]; do
+    echo $snapshot
+    # Make curl request to the API with the current snapshot
+    response=$(curl -X 'GET' "https://data.terra.bio/api/repository/v1/snapshots/$snapshot/files?offset=0&limit=10000" -H 'accept: application/json' -H "Authorization: Bearer $(gcloud auth print-access-token)")
+
+    echo "$response" > "response_$snapshot.json"
+    jq '.[].fileDetail.accessUrl' "response_$snapshot.json" >> list_of_filepaths.txt
+done < "$1"
+
+#Replace gs:// with https://storage.cloud.google.com/
+sed 's|gs://|https://storage.cloud.google.com/|g' list_of_filepaths.txt > tmp_file.txt
+mv tmp_file.txt list_of_filepaths.txt
+
+# Read the list of files from list_of_filepaths.txt and copy them using AzCopy in parallel
+cat list_of_filepaths.txt | xargs -P 5 -I{} azcopy copy "{}" "<INSERT STORAGE SAS URL>"

--- a/scripts/tdr/copy_from_tdr_to_gcs/requirements.txt
+++ b/scripts/tdr/copy_from_tdr_to_gcs/requirements.txt
@@ -1,0 +1,11 @@
+# venv setup
+# python3 -m venv venv
+# source venv/bin/activate
+# pip install -r requirements.txt
+
+os
+sys
+json
+requests
+subprocess
+google-auth


### PR DESCRIPTION
For [FE-235](https://broadworkbench.atlassian.net/browse/FE-235) we decided that it was best for me to write up pseudo code for this copy from TDR back to an HCA staging bucket /data folder, as no one is currently asking for this, nor is it clear they will.

I have validated this on the command line, but we'll probably want this as a script in the future - as a snapshot can have tens of thousands of data files.

This does *not* reconstitute an entire staging bucket directory structure. It will *only* copy the data files back to staging bucket and is only required while we are still on Dagster and do not yet have support for partial updates [DI-75](https://broadworkbench.atlassian.net/browse/DI-75)


[FE-235]: https://broadworkbench.atlassian.net/browse/FE-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DI-75]: https://broadworkbench.atlassian.net/browse/DI-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ