### PR TITLE
FE-408 - Add dry-run and prompt for non-empty staging areas

### DIFF
--- a/scripts/tdr/copy_from_tdr_to_gcs_hca/README.md
+++ b/scripts/tdr/copy_from_tdr_to_gcs_hca/README.md
@@ -15,7 +15,7 @@ or the [Field Eng group](https://groups.google.com/a/broadinstitute.org/g/dsp-fi
 You will want to clone the whole horsefish repo, if you have not done so already.
 
 You will also need a manifest file to run the script.\
-The format of this manifest is identical to the one use for [HCA ingest](https://docs.google.com/document/d/1NQCDlvLgmkkveD4twX5KGv6SZUl8yaIBgz_l1EcrHdA/edit#heading=h.cg8d8o5kklql).
+The format of this manifest is identical to the one used for [HCA ingest](https://docs.google.com/document/d/1NQCDlvLgmkkveD4twX5KGv6SZUl8yaIBgz_l1EcrHdA/edit#heading=h.cg8d8o5kklql).
 A sample manifest is provided in the project directory - dcpTEST_manifest.csv.\
 (Note that this is a test manifest and you will have to first load the data into TDR to use it - see the HCA ingest Ops manual linked above).\
 It's probably easiest to copy out the rows from the original ingest manifest into a new manifest, 
@@ -36,7 +36,13 @@ Next you will want to authenticate with gcloud using your Broad credentials.\
 `gcloud auth application-default login` \
 If you are not in dsp-fieldeng-dev contact Field Eng to get access. \
 Then run the script using the following command syntax:\
-`python3 copy_from_tdr_to_gcs_hca.py <manifest_file>'`
+`python3 copy_from_tdr_to_gcs_hca.py <manifest_file> --dry-run --allow-override'` \
+If you are notified that there are files in the staging area (IE it is non-empty), reach out to the wranglers to \
+determine if the files should be deleted or can be left in the staging area. \
+Run the script again with the appropriate response to the prompt. \
+Once you have the list of files (access_urls_filenames_sorted.txt, in your local project directory), \
+verify that those are the files the wranglers want copied to GCS. \
+If so, run the script again with the `--dry-run` flag removed.
 
 Contact Field Eng for any issues that arise. \
 _*or the monster hca prod project - mystical-slate-284720_

--- a/scripts/tdr/copy_from_tdr_to_gcs_hca/copy_from_tdr_to_gcs_hca.py
+++ b/scripts/tdr/copy_from_tdr_to_gcs_hca/copy_from_tdr_to_gcs_hca.py
@@ -116,11 +116,20 @@ def get_latest_snapshot(target_snapshot: str, access_token: str):
     )
     snapshot_response.raise_for_status()
     latest_snapshot_id = snapshot_response.json()['items'][0]['id']
+    print(latest_snapshot_id)
     return latest_snapshot_id
 
 
-# for each snapshot get access url and add to a list of access urls for that snapshot
 def get_access_urls(snapshot: str, access_token: str):
+    """
+    Retrieves access URLs for files in a given snapshot from the Terra Data Repository (TDR).
+    Also writes the access URLs and filenames to a file for debugging and verification purposes.
+    If there are more than 150 files or there are a mix of sequence and analysis files, check with the wranglers before copying.
+    :param snapshot:
+    :param access_token:
+    :return:
+    """
+
     list_of_access_urls = []
     offset = 0
     limit = 1000
@@ -137,10 +146,24 @@ def get_access_urls(snapshot: str, access_token: str):
         for item in data:
             list_of_access_urls.append(item['fileDetail']['accessUrl'])
         offset += limit
+    num_access_urls = len(list_of_access_urls)
+
+    # for debugging and maybe we want a manifest?
+    logging.info(f'number of access urls for snapshot {snapshot} is {num_access_urls}')
+    with open('access_urls.txt', 'w') as f:
+        for access_url in list_of_access_urls:
+            f.write(f'{access_url}\n')
+    # Extract filenames, sort them, and write to a different file
+    filenames = [access_url.split('/')[-1] for access_url in list_of_access_urls]
+    filenames.sort()
+    with open('access_urls_filenames_sorted.txt', 'w') as f:
+        for filename in filenames:
+            f.write(f'{filename}\n')
+
     return list_of_access_urls
 
 
-def check_staging_is_empty(staging_gs_paths: set[str]):
+def check_staging_is_empty(staging_gs_paths: set[str], allow_override: bool = False):
     nonempty_staging_areas = []
     for staging_dir in staging_gs_paths:
         staging_data_dir = staging_dir + '/data/'
@@ -150,7 +173,7 @@ def check_staging_is_empty(staging_gs_paths: set[str]):
         stdout = output.stdout.strip()
         files = stdout.decode('utf-8').split('\n')
         # in some cases the wranglers may have placed a metadata xslx file in the staging area
-        # if so, set check for > 1, after confirming with the wranglers
+        # if so, proceed through the prompt, after confirming with the wranglers
         if len(files) > 0:
             logging.error(f"Staging area {staging_data_dir} is not empty")
             logging.info(f"files in staging area are: {files}")
@@ -159,67 +182,122 @@ def check_staging_is_empty(staging_gs_paths: set[str]):
             logging.info(f"Staging area {staging_data_dir} is empty")
 
     if len(nonempty_staging_areas) > 0:
-        logging.error("One or more staging areas are not empty. Exiting.")
+        logging.error("One or more staging areas are not empty.")
         logging.info(f"Non-empty staging areas are: {nonempty_staging_areas}")
-        sys.exit(1)
+        if allow_override:
+            user_input = input("Would you like to proceed anyway? (y/n): ")
+            if user_input.lower() == 'y' or user_input.lower() == 'yes':
+                logging.info("User chose to proceed with non-empty staging areas.")
+                return
+            else:
+                logging.info("User chose not to proceed with non-empty staging areas. Exiting.")
+                sys.exit(1)
+        else:
+            sys.exit(1)
 
 
-def copy_tdr_to_staging(tuple_list: list[tuple[str, str]], access_token: str):
+def copy_tdr_to_staging(tuple_list: list[tuple[str, str]], access_token: str, dry_run: bool = False):
+    all_access_urls = {}
     for project_id in set([x[1] for x in tuple_list]):
         target_snapshot = f"hca_prod_{project_id.replace('-', '')}"
         latest_snapshot_id = get_latest_snapshot(target_snapshot, access_token)
         logging.info(f'latest snapshot id for project {project_id} is {latest_snapshot_id}')
         access_urls = get_access_urls(latest_snapshot_id, access_token)
+        all_access_urls[project_id] = access_urls
         num_access_urls = len(access_urls)
-        # for debugging and maybe we want a manifest?
-        # logging.info(f'number of access urls for snapshot {latest_snapshot_id} is {num_access_urls}')
-        # with open('access_urls_dcp49.txt', 'w') as f:
-        #     for access_url in access_urls:
-        #         f.write(f'{access_url}\n')
         staging_gs_path = [x[0] for x in tuple_list if x[1] == project_id][0]
         staging_data_dir = staging_gs_path + '/data/'
+
+        if dry_run:
+            logging.info(f'DRY RUN: Would copy {num_access_urls} files from snapshot {latest_snapshot_id} to staging area {staging_data_dir}')
+            logging.info(f'See local file access_urls.txt for the list of access URLs')
+            continue
+
+        # Get a list of files already in the staging directory before copying
+        output_before = subprocess.run(['gsutil', 'ls', staging_data_dir],
+                                      capture_output=True).stdout.decode('utf-8').split('\n')
+        files_before = set([x.split('/')[-1] for x in output_before if x and x.split('/')[-1]])
+        logging.info(f'Found {len(files_before)} files already in staging area before copying')
+
+        successfully_copied = []
         logging.info(f'Copying {num_access_urls} files from snapshot {latest_snapshot_id} to staging area {staging_data_dir}')
         for access_url in access_urls:
             # strip the filename from the access url because gcp is not a file system - it's all objects
             filename = access_url.split('/')[-1]
             logging.info(f'access_url for snapshot {latest_snapshot_id} is {access_url}')
             try:
-                subprocess.run(['gcloud', 'storage', 'cp', access_url, staging_data_dir + filename])
+                result = subprocess.run(['gcloud', 'storage', 'cp', access_url, staging_data_dir + filename],
+                                      capture_output=True)
+                if result.returncode == 0:
+                    successfully_copied.append(filename)
+                else:
+                    logging.error(f'Error copying {access_url} to {staging_data_dir}{filename}: {result.stderr.decode("utf-8")}')
             except Exception as e:
                 logging.error(f'Error copying {access_url} to {staging_gs_path}{filename}: {e}')
                 continue
-        # visual summary of number of files copied
-        files_copied = subprocess.run(['gsutil', 'ls', staging_data_dir],
-                                      capture_output=True).stdout.decode('utf-8').split('\n')
-        # gsutil outputs the dir and a blank line, so we need to remove the blank line and the dir to count files
-        files_in_dir = [x.split('/')[-1] for x in files_copied if x and x.split('/')[-1]]
-        number_files_copied = len(files_in_dir)
-        logging.info(f'{number_files_copied} out of {num_access_urls} files copied to {staging_data_dir}')
+
+        # Verify what's actually in the staging directory after copying
+        output_after = subprocess.run(['gsutil', 'ls', staging_data_dir],
+                                    capture_output=True).stdout.decode('utf-8').split('\n')
+        files_after = set([x.split('/')[-1] for x in output_after if x and x.split('/')[-1]])
+
+        # Calculate newly copied files (files that exist now but didn't before)
+        newly_copied = files_after - files_before
+
+        # Compare our tracking with what's actually in the directory
+        if len(newly_copied) != len(successfully_copied):
+            logging.warning(f'Tracking mismatch: tracked {len(successfully_copied)} successful copies, '
+                          f'but found {len(newly_copied)} new files in the staging directory')
+
+        # Log the results
+        logging.info(f'{len(successfully_copied)} out of {num_access_urls} files successfully copied to {staging_data_dir}')
+        if len(successfully_copied) < num_access_urls:
+            logging.warning(f'Failed to copy {num_access_urls - len(successfully_copied)} files')
+
+        # For verification, list the files in the staging directory
+        logging.info(f'Files now in staging directory: {len(files_after)}')
+
+    return all_access_urls
 
 
 def main():
     """Parse command-line arguments and run specified tool.
 
-     Note: Does not take explicit input arguments, but uses sys.argv inputs
-     from the command line.
+    Usage: python copy_from_tdr_to_gcs_hca.py <csv_path> [--dry-run] [--allow-override]
 
+    Args:
+        csv_path: Path to a CSV file with institution and project ID.
+        --dry-run: Optional flag. If present, only access URLs will be displayed without copying files.
+        --allow-override: Optional flag. If present, user will be prompted whether to continue
+                        when non-empty staging areas are found.
     """
+    import argparse
+
     setup_cli_logging_format()
     access_token = get_access_token()
 
-    # read in the manifest and get a tuple list of staging gs paths and project ids
-    csv_path = sys.argv[1]
-    validate_input(csv_path)
-    tuple_list = _parse_csv(csv_path)
+    # Set up argument parser
+    parser = argparse.ArgumentParser(description='Copy data from TDR to GCS for HCA projects.')
+    parser.add_argument('csv_path', help='Path to CSV file with institution and project ID')
+    parser.add_argument('--dry-run', action='store_true', help='Only display access URLs without copying files')
+    parser.add_argument('--allow-override', action='store_true',
+                        help='When non-empty staging areas are found, prompt user whether to continue')
+
+    # Parse arguments
+    args = parser.parse_args()
+
+    # Validate input
+    validate_input(args.csv_path)
+    tuple_list = _parse_csv(args.csv_path)
     logging.info(f"staging_gs_paths and project id tuple list is {tuple_list}")
 
     # staging dir is the first element in each tuple
     staging_gs_paths = set([x[0] for x in tuple_list])
 
     # check if the staging area is empty
-    check_staging_is_empty(staging_gs_paths)
+    check_staging_is_empty(staging_gs_paths, args.allow_override)
     # copy the files from the TDR project bucket to the staging area bucket
-    copy_tdr_to_staging(tuple_list, access_token)
+    copy_tdr_to_staging(tuple_list, access_token, args.dry_run)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR

- adds a dry run option which produces a count and list of files to be copied which can then be used to confirm with the wranglers before actually copying the files.
- adds a prompt to allow the ignoring of non-empty staging areas. There is often an updated metadata xslx, but it's best to check, so this flags any files that exist so you can verify how to proceed with the wranglers.
- updates the successfully copied counter to be correct.